### PR TITLE
docs: add ETF cross-asset public-data reproduction (closes #16)

### DIFF
--- a/docs/public_data_mini_reproduction.md
+++ b/docs/public_data_mini_reproduction.md
@@ -94,6 +94,154 @@ Small numerical differences are expected when yfinance revises data or when pand
 PyTorch, or BLAS versions change. Treat large differences as a prompt to check the
 downloaded ticker data, missing values, and dependency versions.
 
+## Second Case: ETF Cross-Asset Universe
+
+This second public-data case expands the cross-section from 10 individual US
+stocks to 20 liquid ETFs spanning broad equity benchmarks, US sectors, fixed
+income, gold, and international equity markets. The purpose remains an API and
+reproducibility check; the results are not a trading recommendation or evidence
+of investable performance.
+
+### Setup
+
+- Commit used as the repository base: `52c894e`
+- Data source: `yfinance` 0.2.40
+- Broad market ETFs: `SPY`, `QQQ`, `IWM`, `DIA`
+- Sector ETFs: `XLK`, `XLF`, `XLE`, `XLV`, `XLY`, `XLP`, `XLI`, `XLB`, `XLU`
+- Cross-asset ETFs: `AGG`, `TLT`, `GLD`, `HYG`
+- International ETFs: `EFA`, `EEM`, `FXI`
+- Date range requested: `2021-01-01` to `2025-01-01` (end exclusive)
+- Date range returned: `2021-01-04` to `2024-12-31`
+- Observations: 1005 dates x 20 ETFs
+- Per-ticker coverage: all 20 ETFs returned 1005 valid OHLCV rows
+- Failed or partial tickers: none
+- Device: CPU
+- Random seed: not used
+
+The factor subset is unchanged from the first case: `best_001`, `best_002`,
+`original_001`, `stock_001`, `add_015`, and `old_042`.
+
+### Reproduction Snippet
+
+The complete reproduction, including a bulk download followed by one-ticker
+retries for any missing columns, is checked in as `scripts/etf_factor_ic.py`.
+From the repository root, run:
+
+```bash
+PYTHONIOENCODING=utf-8 python scripts/etf_factor_ic.py \
+  | tee scripts/etf_factor_ic_output.txt
+```
+
+The factor and IC path used by that script is:
+
+```python
+from scripts.etf_factor_ic import (
+    ETF_UNIVERSE,
+    FACTOR_NAMES,
+    configure_yfinance_user_agent,
+    download_with_fallback,
+    one_day_forward_returns,
+    rank_ic_by_date,
+    summarize_ic,
+)
+from mlquant.features import compute_legacy_set
+
+configure_yfinance_user_agent()
+result = download_with_fallback(ETF_UNIVERSE)
+panel = result.panel
+panel.assert_consistent()
+
+factors, factor_mask, names = compute_legacy_set(panel, names=FACTOR_NAMES)
+fwd_returns, fwd_mask = one_day_forward_returns(panel)
+ic = rank_ic_by_date(
+    factors,
+    fwd_returns,
+    factor_mask & fwd_mask,
+    panel.dates,
+    names,
+)
+summary = summarize_ic(ic)
+print(summary)
+```
+
+The compatibility helper only replaces yfinance's obsolete Chrome 39 user
+agent when that exact default is present. The loader call itself remains
+`make_panel(source="yfinance", ...)`, and newer yfinance versions without that
+legacy default are left unchanged.
+
+### One-Day Forward Rank IC Summary
+
+As in the first case, the table reports daily cross-sectional Spearman rank IC
+between each factor and one-day forward returns. The calculations match
+`notebooks/public_factor_ic.ipynb`, including its warm-up masks and summary
+expressions.
+
+| Factor | Mean IC | Median IC | IC Std | Positive Rate | Observations |
+|---|---:|---:|---:|---:|---:|
+| `original_001` | 0.0131 | 0.0090 | 0.3782 | 0.4965 | 985 |
+| `add_015` | -0.0031 | -0.0060 | 0.3595 | 0.4846 | 985 |
+| `stock_001` | -0.0044 | 0.0030 | 0.2618 | 0.4915 | 985 |
+| `old_042` | -0.0057 | -0.0045 | 0.3108 | 0.4806 | 985 |
+| `best_002` | -0.0061 | -0.0108 | 0.3174 | 0.4746 | 985 |
+| `best_001` | -0.0136 | -0.0030 | 0.3150 | 0.4856 | 982 |
+
+Best mean IC in this ETF run: `original_001`.
+
+### Interpretation
+
+- Expanding from 10 stocks to 20 ETFs changes the factor ordering: `old_042`
+  led the first mini case, while `original_001` has the highest mean IC here.
+  All mean values remain close to zero, so the ranking should be treated as a
+  smoke-test result rather than stable evidence of predictive power.
+- ETFs compress many company-specific effects into portfolio-level returns.
+  The nine sector funds still provide cross-sectional differentiation through
+  sector rotation, but they also share substantial broad-market exposure; that
+  combination can change how stock-oriented legacy factors rank the universe.
+- The bond, gold, and international funds add return drivers that differ from
+  US equity sectors. This broadens the API check, but the aggregate summary does
+  not by itself establish that any factor is stable within each asset subgroup.
+- The two repeated maintainer runs produced byte-identical standard output. That
+  checks deterministic computation against the same downloaded data, not future
+  stability of the upstream public data.
+
+### Caveats
+
+- `yfinance` is a convenient public-data source, not an institutional data
+  contract. Historical adjustments, missing values, endpoint behavior, and
+  rate limits can change after this run.
+- ETF liquidity, trading hours, premiums or discounts, and underlying-market
+  closures differ across the universe. This mini reproduction does not model
+  those differences.
+- ETF survivorship bias is generally less visible than in a stock universe
+  because these selected funds all survived the requested period. The selection
+  is retrospective and does not constitute a point-in-time membership rule.
+- No transaction costs, slippage, portfolio construction, multiple-testing
+  controls, or subgroup significance tests are included.
+- This project and reproduction are for research and engineering experimentation
+  only. They are not financial advice, investment advice, or a trading
+  recommendation.
+
+### Expected Output Check
+
+Use the committed `scripts/etf_factor_ic_output.txt` as the detailed reference.
+A successful rerun should satisfy these checks:
+
+| Check | Maintainer Run |
+|---|---:|
+| Requested ETFs | 20 |
+| Successfully loaded ETFs | 20 |
+| Failed or partial ETFs | 0 |
+| Returned panel | 1005 dates x 20 ETFs |
+| Returned date range | 2021-01-04 to 2024-12-31 |
+| Factor summary rows | 6 |
+| IC observations per factor | 982 to 985 |
+| Highest mean IC | `original_001` at 0.0131 |
+
+Small numerical differences are expected if yfinance revises adjusted history or
+if pandas, PyTorch, SciPy, or yfinance behavior changes. Missing tickers should be
+reported rather than silently replaced, and large IC differences should prompt a
+review of the coverage table, dependency versions, and factor masks.
+
 ## Next Useful Reproductions
 
 - Repeat the workflow on ETFs or sector-balanced universes.

--- a/scripts/etf_factor_ic.py
+++ b/scripts/etf_factor_ic.py
@@ -1,0 +1,328 @@
+"""Reproduce one-day legacy-factor rank IC on a public ETF universe.
+
+The script first requests the complete universe through ``make_panel``. If the
+bulk request fails or returns empty columns, it retries the affected tickers
+one at a time and merges every successful result into one Panel.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+import torch
+import yfinance as yf
+from yfinance import data as yfinance_data
+
+from mlquant.data import Panel, make_panel
+from mlquant.features import compute_legacy_set
+
+ETF_UNIVERSE = (
+    "SPY",
+    "QQQ",
+    "IWM",
+    "DIA",
+    "XLK",
+    "XLF",
+    "XLE",
+    "XLV",
+    "XLY",
+    "XLP",
+    "XLI",
+    "XLB",
+    "XLU",
+    "AGG",
+    "TLT",
+    "GLD",
+    "HYG",
+    "EFA",
+    "EEM",
+    "FXI",
+)
+
+FACTOR_NAMES = (
+    "best_001",
+    "best_002",
+    "original_001",
+    "stock_001",
+    "add_015",
+    "old_042",
+)
+
+START = "2021-01-01"
+END = "2025-01-01"
+DEVICE = "cpu"
+PANEL_FIELDS = ("open", "high", "low", "close", "volume", "vwap")
+
+
+@dataclass(frozen=True)
+class DownloadResult:
+    panel: Panel
+    failed_tickers: tuple[str, ...]
+    bulk_error: str | None
+
+
+def configure_yfinance_user_agent() -> None:
+    """Replace yfinance's obsolete Chrome 39 user agent when present.
+
+    Some Yahoo endpoints reject that legacy user agent with HTTP 429 while
+    accepting the same public chart request from a current generic browser
+    user agent. Newer yfinance releases may not expose either class attribute,
+    in which case this compatibility step is a no-op.
+    """
+    for class_name in ("YfData", "TickerData"):
+        data_class = getattr(yfinance_data, class_name, None)
+        headers = getattr(data_class, "user_agent_headers", None)
+        if isinstance(headers, dict) and "Chrome/39" in headers.get("User-Agent", ""):
+            data_class.user_agent_headers = {"User-Agent": "Mozilla/5.0"}
+
+
+def one_day_forward_returns(panel: Panel) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return one-day forward returns and the corresponding tradability mask."""
+    fwd = torch.roll(panel.returns, shifts=-1, dims=0)
+    fwd[-1] = 0.0
+    tradable_next = panel.mask & torch.roll(panel.mask, shifts=-1, dims=0)
+    tradable_next[-1] = False
+    return fwd, tradable_next
+
+
+def rank_ic_by_date(
+    factor_values: torch.Tensor,
+    returns: torch.Tensor,
+    valid_mask: torch.Tensor,
+    dates: np.ndarray,
+    names: Sequence[str],
+) -> pd.DataFrame:
+    """Calculate daily cross-sectional Spearman rank IC for each factor."""
+    rows: list[dict[str, object]] = []
+    values_np = factor_values.detach().cpu().numpy()
+    returns_np = returns.detach().cpu().numpy()
+    mask_np = valid_mask.detach().cpu().numpy()
+
+    for date_index, date in enumerate(dates):
+        row: dict[str, object] = {"date": pd.Timestamp(date)}
+        for factor_index, name in enumerate(names):
+            mask = mask_np[date_index]
+            values = values_np[date_index, :, factor_index]
+            forward_returns = returns_np[date_index]
+            valid = mask & np.isfinite(values) & np.isfinite(forward_returns)
+            row[name] = (
+                np.nan
+                if valid.sum() < 3
+                else pd.Series(values[valid]).corr(
+                    pd.Series(forward_returns[valid]), method="spearman"
+                )
+            )
+        rows.append(row)
+
+    return pd.DataFrame(rows).set_index("date")
+
+
+def _ticker_slice(panel: Panel, ticker_index: int) -> Panel:
+    fields = {
+        field: getattr(panel, field)[:, ticker_index : ticker_index + 1] for field in PANEL_FIELDS
+    }
+    return Panel.from_tensors(
+        dates=panel.dates,
+        stocks=np.asarray([panel.stocks[ticker_index]]),
+        fields=fields,
+        mask=panel.mask[:, ticker_index : ticker_index + 1],
+    )
+
+
+def _covered_ticker_panels(panel: Panel) -> dict[str, Panel]:
+    covered: dict[str, Panel] = {}
+    for ticker_index, ticker_value in enumerate(panel.stocks):
+        ticker = str(ticker_value)
+        if bool(panel.mask[:, ticker_index].any().item()):
+            covered[ticker] = _ticker_slice(panel, ticker_index)
+    return covered
+
+
+def _merge_ticker_panels(
+    ticker_panels: dict[str, Panel], requested_tickers: Sequence[str]
+) -> Panel:
+    successful_tickers = [ticker for ticker in requested_tickers if ticker in ticker_panels]
+    if not successful_tickers:
+        raise RuntimeError("yfinance returned no usable ETF data")
+
+    dates = np.unique(
+        np.concatenate([ticker_panels[ticker].dates for ticker in successful_tickers])
+    )
+    shape = (len(dates), len(successful_tickers))
+    fields = {
+        field: torch.zeros(shape, dtype=torch.float32, device=DEVICE) for field in PANEL_FIELDS
+    }
+    mask = torch.zeros(shape, dtype=torch.bool, device=DEVICE)
+
+    for ticker_index, ticker in enumerate(successful_tickers):
+        source = ticker_panels[ticker]
+        date_indices = np.searchsorted(dates, source.dates)
+        target_indices = torch.as_tensor(date_indices, dtype=torch.long, device=DEVICE)
+        for field in PANEL_FIELDS:
+            fields[field][target_indices, ticker_index] = getattr(source, field)[:, 0]
+        mask[target_indices, ticker_index] = source.mask[:, 0]
+
+    return Panel.from_tensors(
+        dates=dates,
+        stocks=np.asarray(successful_tickers),
+        fields=fields,
+        mask=mask,
+    )
+
+
+def download_with_fallback(tickers: Sequence[str]) -> DownloadResult:
+    """Try one bulk yfinance request, then retry absent tickers individually."""
+    ticker_panels: dict[str, Panel] = {}
+    bulk_error: str | None = None
+
+    try:
+        bulk_panel = make_panel(
+            source="yfinance",
+            tickers=tuple(tickers),
+            start=START,
+            end=END,
+            device=DEVICE,
+        )
+        ticker_panels.update(_covered_ticker_panels(bulk_panel))
+    except Exception as exc:  # yfinance raises several provider-specific errors
+        bulk_error = f"{type(exc).__name__}: {exc}"
+
+    retry_tickers = [ticker for ticker in tickers if ticker not in ticker_panels]
+    for ticker in retry_tickers:
+        try:
+            single_panel = make_panel(
+                source="yfinance",
+                tickers=(ticker,),
+                start=START,
+                end=END,
+                device=DEVICE,
+            )
+        except Exception:
+            continue
+        if bool(single_panel.mask.any().item()):
+            ticker_panels[ticker] = _ticker_slice(single_panel, 0)
+
+    failed_tickers = tuple(ticker for ticker in tickers if ticker not in ticker_panels)
+    panel = _merge_ticker_panels(ticker_panels, tickers)
+    panel.assert_consistent()
+    return DownloadResult(panel, failed_tickers, bulk_error)
+
+
+def coverage_table(
+    panel: Panel, requested_tickers: Sequence[str], failed_tickers: Sequence[str]
+) -> pd.DataFrame:
+    """Summarize valid OHLCV coverage for every requested ticker."""
+    panel_lookup = {str(ticker): index for index, ticker in enumerate(panel.stocks)}
+    failed = set(failed_tickers)
+    rows = []
+
+    for ticker in requested_tickers:
+        if ticker in failed:
+            rows.append(
+                {
+                    "ticker": ticker,
+                    "status": "failed",
+                    "observations": 0,
+                    "first_date": "-",
+                    "last_date": "-",
+                    "coverage_rate": 0.0,
+                }
+            )
+            continue
+
+        ticker_index = panel_lookup[ticker]
+        valid_indices = panel.mask[:, ticker_index].detach().cpu().numpy().nonzero()[0]
+        observations = int(valid_indices.size)
+        rows.append(
+            {
+                "ticker": ticker,
+                "status": "full" if observations == panel.n_dates else "partial",
+                "observations": observations,
+                "first_date": str(pd.Timestamp(panel.dates[valid_indices[0]]).date()),
+                "last_date": str(pd.Timestamp(panel.dates[valid_indices[-1]]).date()),
+                "coverage_rate": observations / panel.n_dates,
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+def summarize_ic(ic: pd.DataFrame) -> pd.DataFrame:
+    """Match the summary calculation in public_factor_ic.ipynb."""
+    return pd.DataFrame(
+        {
+            "mean_ic": ic.mean(skipna=True),
+            "median_ic": ic.median(skipna=True),
+            "ic_std": ic.std(skipna=True),
+            "positive_rate": (ic > 0).mean(skipna=True),
+            "observations": ic.count(),
+        }
+    ).sort_values("mean_ic", ascending=False)
+
+
+def print_coverage(coverage: pd.DataFrame) -> None:
+    print("Per-ticker data coverage:")
+    print(
+        f"{'Ticker':<8} {'Status':<8} {'Observations':>12} "
+        f"{'First Date':>12} {'Last Date':>12} {'Coverage':>10}"
+    )
+    print("-" * 69)
+    for row in coverage.itertuples(index=False):
+        print(
+            f"{row.ticker:<8} {row.status:<8} {row.observations:>12d} "
+            f"{row.first_date:>12} {row.last_date:>12} {row.coverage_rate:>9.2%}"
+        )
+
+
+def print_ic_summary(summary: pd.DataFrame) -> None:
+    print("One-day forward Spearman rank IC summary:")
+    print(
+        f"{'Factor':<16} {'Mean IC':>9} {'Median IC':>11} "
+        f"{'IC Std':>9} {'Positive Rate':>14} {'Observations':>13}"
+    )
+    print("-" * 78)
+    for factor, row in summary.iterrows():
+        print(
+            f"{factor:<16} {row['mean_ic']:>9.4f} {row['median_ic']:>11.4f} "
+            f"{row['ic_std']:>9.4f} {row['positive_rate']:>13.2%} "
+            f"{int(row['observations']):>13d}"
+        )
+
+
+def main() -> None:
+    configure_yfinance_user_agent()
+    result = download_with_fallback(ETF_UNIVERSE)
+    panel = result.panel
+
+    print("ETF cross-asset public-data reproduction")
+    print(f"yfinance version: {yf.__version__}")
+    print(f"Requested date range: {START} to {END} (end exclusive)")
+    print(
+        "Returned panel: "
+        f"{panel.n_dates} dates x {panel.n_stocks} ETFs, "
+        f"{pd.Timestamp(panel.dates[0]).date()} to "
+        f"{pd.Timestamp(panel.dates[-1]).date()}"
+    )
+    print(f"Bulk download error: {result.bulk_error or 'none'}")
+    print(
+        "Failed tickers: " + (", ".join(result.failed_tickers) if result.failed_tickers else "none")
+    )
+    print()
+
+    coverage = coverage_table(panel, ETF_UNIVERSE, result.failed_tickers)
+    print_coverage(coverage)
+    print()
+
+    factors, factor_mask, names = compute_legacy_set(panel, names=FACTOR_NAMES)
+    forward_returns, forward_mask = one_day_forward_returns(panel)
+    valid_mask = factor_mask & forward_mask
+    ic = rank_ic_by_date(factors, forward_returns, valid_mask, panel.dates, names)
+    summary = summarize_ic(ic)
+    print_ic_summary(summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/etf_factor_ic_output.txt
+++ b/scripts/etf_factor_ic_output.txt
@@ -1,0 +1,40 @@
+ETF cross-asset public-data reproduction
+yfinance version: 0.2.40
+Requested date range: 2021-01-01 to 2025-01-01 (end exclusive)
+Returned panel: 1005 dates x 20 ETFs, 2021-01-04 to 2024-12-31
+Bulk download error: none
+Failed tickers: none
+
+Per-ticker data coverage:
+Ticker   Status   Observations   First Date    Last Date   Coverage
+---------------------------------------------------------------------
+SPY      full             1005   2021-01-04   2024-12-31   100.00%
+QQQ      full             1005   2021-01-04   2024-12-31   100.00%
+IWM      full             1005   2021-01-04   2024-12-31   100.00%
+DIA      full             1005   2021-01-04   2024-12-31   100.00%
+XLK      full             1005   2021-01-04   2024-12-31   100.00%
+XLF      full             1005   2021-01-04   2024-12-31   100.00%
+XLE      full             1005   2021-01-04   2024-12-31   100.00%
+XLV      full             1005   2021-01-04   2024-12-31   100.00%
+XLY      full             1005   2021-01-04   2024-12-31   100.00%
+XLP      full             1005   2021-01-04   2024-12-31   100.00%
+XLI      full             1005   2021-01-04   2024-12-31   100.00%
+XLB      full             1005   2021-01-04   2024-12-31   100.00%
+XLU      full             1005   2021-01-04   2024-12-31   100.00%
+AGG      full             1005   2021-01-04   2024-12-31   100.00%
+TLT      full             1005   2021-01-04   2024-12-31   100.00%
+GLD      full             1005   2021-01-04   2024-12-31   100.00%
+HYG      full             1005   2021-01-04   2024-12-31   100.00%
+EFA      full             1005   2021-01-04   2024-12-31   100.00%
+EEM      full             1005   2021-01-04   2024-12-31   100.00%
+FXI      full             1005   2021-01-04   2024-12-31   100.00%
+
+One-day forward Spearman rank IC summary:
+Factor             Mean IC   Median IC    IC Std  Positive Rate  Observations
+------------------------------------------------------------------------------
+original_001        0.0131      0.0090    0.3782        49.65%           985
+add_015            -0.0031     -0.0060    0.3595        48.46%           985
+stock_001          -0.0044      0.0030    0.2618        49.15%           985
+old_042            -0.0057     -0.0045    0.3108        48.06%           985
+best_002           -0.0061     -0.0108    0.3174        47.46%           985
+best_001           -0.0136     -0.0030    0.3150        48.56%           982


### PR DESCRIPTION
## Summary

Adds a second public-data mini reproduction case using 20 ETFs across asset classes, as requested in #16.

## Changes

| File | Description |
|------|-------------|
| `scripts/etf_factor_ic.py` | Standalone reproduction script (328 lines) — downloads ETF data via yfinance, computes 6 legacy factors, reports one-day forward rank IC |
| `scripts/etf_factor_ic_output.txt` | Committed output from a clean run for reproducibility verification |
| `docs/public_data_mini_reproduction.md` | New "Second Case: ETF Cross-Asset Universe" section appended before "Next Useful Reproductions" |

## ETF Universe

20 ETFs across 5 categories — all 20 downloaded successfully with 100% coverage (1005 dates each):

- **Broad market (4)**: SPY, QQQ, IWM, DIA
- **Sector (9)**: XLK, XLF, XLE, XLV, XLY, XLP, XLI, XLB, XLU
- **Fixed income (2)**: AGG, TLT
- **Cross-asset (2)**: GLD, HYG
- **International (3)**: EFA, EEM, FXI

## Key Results

| Factor | Mean IC | Observations |
|---|---:|---:|
| `original_001` | 0.0131 | 985 |
| `add_015` | -0.0031 | 985 |
| `stock_001` | -0.0044 | 985 |
| `old_042` | -0.0057 | 985 |
| `best_002` | -0.0061 | 985 |
| `best_001` | -0.0136 | 982 |

As expected, ETF-level IC values are lower than the equity case — stock-oriented legacy factors have reduced cross-sectional discrimination on portfolio-level instruments. This is documented in the Interpretation and Caveats sections.

## Verification

- ✅ `pytest` — all tests pass, no regressions
- ✅ `ruff check .` — no linting issues
- ✅ First case content in `public_data_mini_reproduction.md` is unchanged
- ✅ Document follows the same format as the existing first case
- ✅ Disclaimer included: reproducibility/API check only, not a trading recommendation

## Technical Note

The script includes a yfinance user-agent compatibility fix (`configure_yfinance_user_agent()`) for yfinance 0.2.40's obsolete Chrome 39 default header, which was causing HTTP 429 rejections. This workaround is a no-op on versions without that legacy default.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
