### PR TITLE
docs: document contributor operations workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,24 @@ pip install -e .[mosek]    # MOSEK license may be required
 - Run `pytest` and `ruff check .` before opening the PR.
 - Avoid committing private market data, credentials, broker configuration, or large generated artifacts.
 
+## Contributor Workflow
+
+Use issues as the source of truth for upcoming work. The roadmap in
+`docs/roadmap.md` is intentionally lightweight so contributors can see the next
+useful tasks without needing access to a private project board.
+
+Recommended flow:
+
+1. Open or claim an issue before doing a larger change.
+2. Keep pull requests small enough to review in one sitting.
+3. Link the PR to the issue it addresses.
+4. Include the command output or environment details for benchmark and
+   reproducibility changes.
+5. Prefer human review and CI signals before introducing automated review tools.
+
+Automated review assistance may be used later for repetitive checks, but it
+should not replace clear tests, reproducible examples, or maintainer judgment.
+
 ## Research Reproducibility
 
 When reporting results, include the config, random seed, data source, date range, benchmark universe, transaction-cost assumptions, and evaluation metrics. Results that depend on proprietary data are welcome, but please provide a synthetic or public-data reproduction path when possible.

--- a/docs/community.md
+++ b/docs/community.md
@@ -38,6 +38,26 @@ Document ablations, failed experiments, or limitations. Honest negative results 
 - Keep issues small enough for first-time contributors.
 - Prefer clear caveats over inflated claims.
 
+## Contributor Operations
+
+The project should stay easy to contribute to without requiring proprietary
+tools or private maintainer context.
+
+Current decision:
+
+- Use GitHub issues plus `docs/roadmap.md` as the public contributor board.
+- Keep labels focused on contribution type and review priority.
+- Link each community request, benchmark report, or reproduction PR back to a
+  small issue when practical.
+- Defer a formal GitHub Project board until there are enough simultaneous
+  contributor tasks to justify the extra maintenance.
+- Defer automated PR review services until repeated review bottlenecks appear.
+
+Review automation can help with style, missing tests, and documentation drift,
+but it should not generate noisy comments or gate small documentation
+contributions. CI, reproducible commands, and maintainer review remain the
+baseline workflow.
+
 ## Labels to Use
 
 - `good first issue`: small, self-contained contribution.


### PR DESCRIPTION
## Summary\n- document the lightweight contributor workflow in CONTRIBUTING.md\n- record the current community operations decision in docs/community.md\n- clarify that issues + roadmap are the public contributor board for now, while PR automation stays deferred until it is useful\n\nCloses #17.\n\n## Validation\n- /Users/duyimin/Documents/Codex/2026-07-04/ban/work/bench-venv/bin/python -m ruff check src tests scripts\n- /Users/duyimin/Documents/Codex/2026-07-04/ban/work/bench-venv/bin/python -m pytest