### PR TITLE
fix: handle sparse downside sortino samples

### DIFF
--- a/src/mlquant/backtest/metrics.py
+++ b/src/mlquant/backtest/metrics.py
@@ -41,8 +41,10 @@ def sortino_ratio(returns: np.ndarray, *, rf: float = 0.0, periods: int = DAYS_P
     downside = excess[excess < 0]
     if downside.size == 0:
         return float("inf")
+    if downside.size < 2:
+        return 0.0
     dd = downside.std(ddof=1)
-    if dd < 1e-12:
+    if not np.isfinite(dd) or dd < 1e-12:
         return 0.0
     return float(excess.mean() / dd * np.sqrt(periods))
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -48,3 +48,13 @@ def test_sortino_and_calmar_finite_on_random():
     assert np.isfinite(sortino_ratio(r))
     assert np.isfinite(calmar_ratio(r))
     assert np.isfinite(annualised_vol(r))
+
+
+def test_sortino_handles_single_downside_observation():
+    r = np.array([0.02, 0.01, -0.005, 0.03])
+    assert sortino_ratio(r) == 0.0
+
+
+def test_sortino_inf_when_no_downside_observations():
+    r = np.array([0.01, 0.02, 0.03])
+    assert sortino_ratio(r) == float("inf")


### PR DESCRIPTION
## Summary\n- avoid returning nan from sortino_ratio when there is only one downside return\n- keep the no-downside case as +inf\n- add regression tests for both sparse-downside and no-downside cases\n\n## Validation\n- /Users/duyimin/Documents/Codex/2026-07-04/ban/work/bench-venv/bin/python -m ruff check src tests scripts\n- /Users/duyimin/Documents/Codex/2026-07-04/ban/work/bench-venv/bin/python -m pytest