### PR TITLE
fix: escape validation leaderboard markdown cells

### DIFF
--- a/scripts/aggregate_validation_reports.py
+++ b/scripts/aggregate_validation_reports.py
@@ -69,6 +69,11 @@ def _fmt(value: Any) -> str:
     return "" if value is None else str(value)
 
 
+def _md_cell(value: Any) -> str:
+    """Format a value for a Markdown table cell."""
+    return _fmt(value).replace("|", "\\|")
+
+
 def _flatten_report(path: Path) -> list[dict[str, Any]]:
     report = json.loads(path.read_text())
     metadata = report.get("metadata", {})
@@ -124,7 +129,7 @@ def markdown_table(rows: Sequence[dict[str, Any]]) -> str:
         "| " + " | ".join(["---"] * len(LEADERBOARD_COLUMNS)) + " |",
     ]
     for row in rows:
-        lines.append("| " + " | ".join(_fmt(row.get(column)) for column in LEADERBOARD_COLUMNS) + " |")
+        lines.append("| " + " | ".join(_md_cell(row.get(column)) for column in LEADERBOARD_COLUMNS) + " |")
     return "\n".join(lines)
 
 

--- a/tests/test_aggregate_validation_reports.py
+++ b/tests/test_aggregate_validation_reports.py
@@ -14,7 +14,7 @@ def _write_report(path: Path, *, preset: str, strategy: str, sharpe: float) -> N
                     "preset": preset,
                     "python": "3.11.0",
                     "pytorch": "2.8.0",
-                    "platform": "test",
+                    "platform": "Linux | test",
                     "panel": {
                         "date_start": "2021-01-01",
                         "date_end": "2021-12-31",
@@ -49,6 +49,7 @@ def test_aggregate_validation_reports(tmp_path: Path):
     table = markdown_table(rows)
     assert "fast" in table
     assert "1.5000" in table
+    assert "Linux \\| test" in table
 
     write_markdown(tmp_path / "leaderboard.md", rows)
     write_csv(tmp_path / "leaderboard.csv", rows)


### PR DESCRIPTION
## Summary
- escape pipe characters when rendering validation leaderboard Markdown cells
- add regression coverage for platform strings containing pipe characters

## Validation
- /Users/duyimin/Documents/Codex/2026-07-04/ban/work/bench-venv/bin/python -m ruff check src tests scripts
- /Users/duyimin/Documents/Codex/2026-07-04/ban/work/bench-venv/bin/python -m pytest tests/test_aggregate_validation_reports.py
- /Users/duyimin/Documents/Codex/2026-07-04/ban/work/bench-venv/bin/python -m pytest