### PR TITLE
fix: escape audit report markdown cells

### DIFF
--- a/scripts/audit_validation_report.py
+++ b/scripts/audit_validation_report.py
@@ -132,6 +132,10 @@ def has_errors(findings: Sequence[AuditFinding]) -> bool:
     return any(item.severity == "error" for item in findings)
 
 
+def _markdown_cell(value: object) -> str:
+    return str(value).replace("|", "\\|")
+
+
 def markdown_report(findings: Sequence[AuditFinding], *, source: Path) -> str:
     lines = [
         "# Validation Report Audit",
@@ -142,7 +146,9 @@ def markdown_report(findings: Sequence[AuditFinding], *, source: Path) -> str:
         "|---|---|---|",
     ]
     for item in findings:
-        lines.append(f"| {item.severity} | `{item.check}` | {item.message} |")
+        lines.append(
+            f"| {_markdown_cell(item.severity)} | `{_markdown_cell(item.check)}` | {_markdown_cell(item.message)} |"
+        )
     return "\n".join(lines) + "\n"
 
 

--- a/tests/test_audit_validation_report.py
+++ b/tests/test_audit_validation_report.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-from scripts.audit_validation_report import audit_report, has_errors, markdown_report
+from scripts.audit_validation_report import AuditFinding, audit_report, has_errors, markdown_report
 
 
 def _valid_report():
@@ -65,3 +65,13 @@ def test_audit_validation_report_flags_errors_and_warnings():
 def test_audit_validation_report_fixture_is_json_serializable():
     encoded = json.dumps(_valid_report())
     assert "equal_weight" in encoded
+
+
+def test_audit_validation_report_markdown_escapes_pipes(tmp_path: Path):
+    text = markdown_report(
+        [AuditFinding("warning", "panel|coverage", "value contains | pipe")],
+        source=tmp_path / "summary.json",
+    )
+
+    assert "panel\\|coverage" in text
+    assert "value contains \\| pipe" in text


### PR DESCRIPTION
## Summary
- escape pipe characters in audit report Markdown table cells
- add regression coverage for audit checks/messages containing pipe characters

## Validation
- /Users/duyimin/Documents/Codex/2026-07-04/ban/work/bench-venv/bin/python -m ruff check src tests scripts
- /Users/duyimin/Documents/Codex/2026-07-04/ban/work/bench-venv/bin/python -m pytest tests/test_audit_validation_report.py
- /Users/duyimin/Documents/Codex/2026-07-04/ban/work/bench-venv/bin/python -m pytest