### PR TITLE
Add pairing contribution workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/pairing_request.yml
+++ b/.github/ISSUE_TEMPLATE/pairing_request.yml
@@ -1,0 +1,60 @@
+name: Pairing request
+description: Propose a small co-authored contribution or ask to pair on an existing task.
+title: "[pairing] "
+labels: ["community", "good first issue", "pairing"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing a pairing task. The best pairing requests are small,
+        reproducible, and clear about what each contributor will do.
+
+  - type: textarea
+    id: task
+    attributes:
+      label: Task
+      description: What should the paired contribution change or validate?
+      placeholder: Run a public-data validation report, add a focused benchmark, document an edge case, or add a small test.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_split
+    attributes:
+      label: Proposed split
+      description: How can the work be split between contributors?
+      placeholder: |
+        Contributor A:
+        Contributor B:
+        Maintainer help needed:
+    validations:
+      required: true
+
+  - type: textarea
+    id: commands
+    attributes:
+      label: Reproduction commands
+      description: Paste the commands or checklist needed to verify the paired work.
+      render: bash
+      placeholder: python scripts/public_data_validation.py --source yfinance --preset etf-20
+    validations:
+      required: false
+
+  - type: textarea
+    id: expected_output
+    attributes:
+      label: Expected output
+      description: What artifact, report, table, test, or doc page should the PR include?
+    validations:
+      required: true
+
+  - type: textarea
+    id: coauthor_notes
+    attributes:
+      label: Co-author notes
+      description: Mention who will contribute materially. Co-authored-by trailers should only be added when each person contributes to the PR.
+      placeholder: |
+        Proposed co-authors:
+        Contribution evidence:
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,10 @@
 
 Describe the change and why it is useful.
 
+Linked issue:
+
+- Closes #
+
 ## Type of change
 
 - [ ] Bug fix
@@ -15,6 +19,13 @@ Describe the change and why it is useful.
 - [ ] I added or updated tests where appropriate.
 - [ ] I updated docs or examples where behavior changed.
 - [ ] I did not commit private data, credentials, or large generated artifacts.
+
+## Collaboration
+
+- [ ] This PR is a solo contribution.
+- [ ] This PR includes real paired work and the commit message includes accurate `Co-authored-by:` trailers.
+
+If this is a paired contribution, briefly describe what each contributor did:
 
 ## Validation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,21 @@ Recommended flow:
 Automated review assistance may be used later for repetitive checks, but it
 should not replace clear tests, reproducible examples, or maintainer judgment.
 
+## Paired Contributions
+
+Paired contributions are welcome when the work can be split clearly. Good
+pairing candidates include public-data validation reports, benchmark runs on
+different hardware, focused docs improvements, and small tests for edge cases.
+
+Use the pairing request issue template when you want to pair on a task. A good
+request should include the proposed task, the split of work, reproduction
+commands, and the expected PR output.
+
+Only add `Co-authored-by:` trailers when each named person materially
+contributed to the merged PR. Useful contributions include writing code or docs,
+running and interpreting a reproducible benchmark, debugging a failing test, or
+reviewing generated reports closely enough to change the final result.
+
 ## Research Reproducibility
 
 When reporting results, include the config, random seed, data source, date range, benchmark universe, transaction-cost assumptions, and evaluation metrics. Results that depend on proprietary data are welcome, but please provide a synthetic or public-data reproduction path when possible.

--- a/docs/community.md
+++ b/docs/community.md
@@ -9,6 +9,14 @@ The project grows best when people can contribute small, credible improvements.
 Run the benchmark script and submit hardware/runtime details. This is the easiest way to help
 without changing code.
 
+### Paired Contributions
+
+Open a pairing request when a contribution would benefit from two people, such
+as one person running a public-data validation and another turning the result
+into a reviewed report. Keep the task small, include reproduction commands, and
+only use co-author trailers for people who materially contributed to the merged
+PR.
+
 ### Public-Data Examples
 
 Add a notebook or docs page that uses a public data source. Keep the universe small, state


### PR DESCRIPTION
## Summary

Adds a pairing request issue template and updates contributor guidance so real co-authored work has a clear, reproducible path.

## Why

This makes it easier for external contributors to propose public-data validation, benchmark, docs, or small test work that can be split cleanly between two people. It also clarifies when `Co-authored-by:` trailers are appropriate.

## Validation

```text
ruby -e 'require "yaml"; Dir[".github/ISSUE_TEMPLATE/*.yml"].sort.each { |f| YAML.load_file(f); puts "ok #{f}" }'\n```