### PR TITLE
fix: harden neutralization and Baostock data handling

### DIFF
--- a/docs/validation_baostock_20260716.md
+++ b/docs/validation_baostock_20260716.md
@@ -1,0 +1,58 @@
+# Baostock A-Share Public-Data Validation Report
+
+> 2026-07-16 · Windows 11 · PyTorch 2.13.0+cpu · Python 3.12.7
+
+## Command
+
+```bash
+python scripts/public_data_validation.py \
+  --source baostock \
+  --preset cn-large-25 \
+  --max-tickers 25 \
+  --cost-grid-bps 0,7,15,30 \
+  --bootstrap-samples 100
+```
+
+## Environment
+
+| Item | Value |
+|------|-------|
+| OS | Windows 11 (10.0.26100) |
+| Python | 3.12.7 |
+| PyTorch | 2.13.0+cpu |
+| CUDA | Not available |
+
+## Data Coverage
+
+| Field | Value |
+|------|-------|
+| Source | baostock |
+| Tickers | 25 (SSE 15 + SZSE 10 A-share blue chips) |
+| Date range | 2021-01-04 to 2024-12-31 |
+| Trading days | 969 |
+| Tradable ratio | 100% (all 25 tickers downloaded successfully) |
+| Stocks with no data | none |
+
+## Results (7 bps effective cost)
+
+| strategy | ann_return | sharpe | max_dd | turnover | cost_drag |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| equal_weight | +1.7% | 0.18 | 28.8% | 0.001 | 0.07% |
+| momentum_20 | +0.2% | 0.14 | 41.6% | 0.179 | 24.2% |
+| alpha101_mean | −23.2% | −1.02 | 73.1% | 0.533 | 72.2% |
+| mlp_alpha101 | −11.9% | −0.81 | 53.5% | 0.272 | 36.8% |
+| transformer_alpha101 | −6.0% | −0.38 | 35.3% | 0.282 | 38.2% |
+
+Equal-weight positive (+1.7%), factor and ML strategies negative — consistent with A-share conditions over 2021–2024 where buy-and-hold a diversified basket modestly outperformed naive factor rotation.
+
+## Cost sensitivity
+
+At 30 bps, high-turnover strategies suffer disproportionately:
+- alpha101_mean Sharpe drops from −0.21 (0 bps) → −3.62 (30 bps), cost drag 309%
+- equal_weight Sharpe barely moves (0.185 → 0.182), cost drag only 0.3%
+
+Bootstrap CIs (100 samples, block 20 days) included for all scenarios.
+
+## Key packages
+
+numpy==2.4.4 · pandas==3.0.2 · scipy==1.17.1 · scikit-learn==1.8.0 · torch==2.13.0+cpu · cvxpy==1.9.2 · scs==3.2.11 · click==8.4.1 · baostock==00.9.10

--- a/scripts/public_data_validation.py
+++ b/scripts/public_data_validation.py
@@ -60,10 +60,19 @@ ETF_50 = (
     "EWT", "EWJ", "EWG", "EWU", "FXI", "MCHI", "INDA", "EWZ", "EWW", "EWC",
 )
 
+CN_LARGE_25 = (
+    "sh.600000", "sh.600036", "sh.600519", "sh.600585", "sh.600809",
+    "sh.600887", "sh.601012", "sh.601088", "sh.601166", "sh.601318",
+    "sh.601398", "sh.601668", "sh.601857", "sh.601888", "sh.601899",
+    "sz.000001", "sz.000002", "sz.000333", "sz.000651", "sz.000858",
+    "sz.002415", "sz.002594", "sz.300750", "sz.300059", "sz.300124",
+)
+
 PRESETS = {
     "us-large-100": US_LARGE_100,
     "etf-50": ETF_50,
     "mixed-150": US_LARGE_100 + ETF_50,
+    "cn-large-25": CN_LARGE_25,
 }
 
 DEFAULT_MODELS = ("equal_weight", "momentum_20", "alpha101_mean", "mlp_alpha101", "transformer_alpha101")
@@ -130,16 +139,20 @@ def _parse_cost_grid(value: str) -> tuple[float, ...]:
     return tuple(dict.fromkeys(costs))
 
 
-def _select_tickers(preset: str, tickers: str, max_tickers: int) -> tuple[str, ...]:
+def _select_tickers(preset: str, tickers: str, max_tickers: int, source: str = "yfinance") -> tuple[str, ...]:
     if tickers:
-        selected = tuple(t.strip().upper() for t in tickers.split(",") if t.strip())
+        raw = tuple(t.strip() for t in tickers.split(",") if t.strip())
+        if source == "baostock":
+            selected = raw  # preserve case: baostock uses lowercase exchange prefixes
+        else:
+            selected = tuple(t.upper() for t in raw)
     else:
         selected = PRESETS[preset]
     return selected[:max_tickers]
 
 
 def load_validation_panel(cfg: ValidationConfig) -> Panel:
-    """Load either a public yfinance panel or a deterministic synthetic panel."""
+    """Load a public-data, Baostock A-share, or deterministic synthetic panel."""
     if cfg.source == "synthetic":
         return make_synthetic_panel(
             SyntheticConfig(
@@ -148,6 +161,14 @@ def load_validation_panel(cfg: ValidationConfig) -> Panel:
                 seed=cfg.seed,
                 device=cfg.device,
             )
+        )
+    if cfg.source == "baostock":
+        return make_panel(
+            source="baostock",
+            tickers=cfg.tickers,
+            start=cfg.start,
+            end=cfg.end,
+            device=cfg.device,
         )
     return make_panel(
         source="yfinance",
@@ -728,7 +749,7 @@ def _write_outputs(
 
 
 @click.command()
-@click.option("--source", type=click.Choice(["yfinance", "synthetic"]), default="yfinance", show_default=True)
+@click.option("--source", type=click.Choice(["yfinance", "synthetic", "baostock"]), default="yfinance", show_default=True)
 @click.option("--preset", type=click.Choice(sorted(PRESETS)), default="us-large-100", show_default=True)
 @click.option("--tickers", default="", help="Comma-separated tickers. Overrides --preset.")
 @click.option("--start", default="2021-01-01", show_default=True)
@@ -783,7 +804,7 @@ def main(
     cfg = ValidationConfig(
         source=source,
         preset=preset,
-        tickers=_select_tickers(preset, tickers, max_tickers),
+        tickers=_select_tickers(preset, tickers, max_tickers, source),
         start=start,
         end=end,
         max_tickers=max_tickers,

--- a/src/mlquant/data/baostock_loader.py
+++ b/src/mlquant/data/baostock_loader.py
@@ -102,12 +102,16 @@ def load_baostock_panel(
     fields_wide["last_close"] = preclose_df
 
     if proxy_vwap:
-        # Avoid division by zero by filling NaNs or 0s
-        # Only compute vwap where volume > 0, otherwise use proxy
-        vwap_actual = amount_df / volume_df
-        # If amount or volume is 0 or NaN, fallback to typical price
+        # OHLC are forward-adjusted (adjustflag="2"); (O+H+L+C)/4 is internally
+        # consistent.  Using amount/volume would mix unadjusted and adjusted data.
+        fields_wide["vwap"] = (open_df + close_df + high_df + low_df) / 4.0
+    else:
+        # amount and volume are NOT forward-adjusted, so vwap_actual is raw.
+        # Still fall back to proxy where data is missing.
+        vwap_raw = (amount_df / volume_df.replace(0, np.nan)).fillna(np.nan)
+        vwap_raw = vwap_raw.replace([np.inf, -np.inf], np.nan)
         vwap_proxy = (open_df + close_df + high_df + low_df) / 4.0
-        fields_wide["vwap"] = vwap_actual.fillna(vwap_proxy).replace([np.inf, -np.inf], np.nan).fillna(vwap_proxy)
+        fields_wide["vwap"] = vwap_raw.fillna(vwap_proxy)
 
     dates = open_df.index.to_numpy()
     stocks = list(unique_tickers)

--- a/src/mlquant/features/neutralize.py
+++ b/src/mlquant/features/neutralize.py
@@ -62,8 +62,14 @@ def neutralize_industry(
         # least-squares  Xβ = y   via lstsq for numerical stability
         beta = torch.linalg.lstsq(X, y.unsqueeze(1)).solution.squeeze(1)
         residual = y - X @ beta
-        # cross-sectional z-score the residual to scale-normalise
-        residual = (residual - residual.mean()) / residual.std().clamp_min(1e-12)
+        # Degeneracy guard: if the signal is almost entirely explained by the
+        # regressors (float32 lstsq residual std ∼ 1e-7 for a perfect fit),
+        # return zero rather than amplifying tiny noise to unit variance.
+        rms_residual = residual.std(unbiased=False)
+        if rms_residual < 1e-6:
+            out[t][m] = 0.0
+            continue
+        residual = (residual - residual.mean()) / rms_residual.clamp_min(1e-6)
         out[t][m] = residual
 
     return out

--- a/tests/test_neutralize.py
+++ b/tests/test_neutralize.py
@@ -1,0 +1,288 @@
+"""Cross-sectional and industry neutralisation tests.
+
+Tests verify both the mathematical properties (mean zero, orthogonality,
+unit-variance) and numerical-stability edge cases.
+"""
+from __future__ import annotations
+
+import torch
+import pytest
+
+from mlquant.data.synthetic import SyntheticConfig, make_synthetic_panel
+from mlquant.features.neutralize import neutralize_cs, neutralize_industry
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+def _make_onehot(n_stocks: int, n_industries: int) -> torch.Tensor:
+    """Per-stock industry one-hot [1, N, K] with round-robin assignment."""
+    onehot = torch.zeros(1, n_stocks, n_industries)
+    for i in range(n_stocks):
+        onehot[0, i, i % n_industries] = 1.0
+    return onehot
+
+
+# =============================================================================
+# neutralize_cs
+# =============================================================================
+
+
+def test_neutralize_cs_mean_zero():
+    """Per-date cross-sectional z-score has mean≈0 on valid cells."""
+    p = make_synthetic_panel(SyntheticConfig(n_stocks=50, n_dates=60, seed=1))
+    out = neutralize_cs(p.close, p.mask)
+    for t in range(p.mask.shape[0]):
+        valid = p.mask[t]
+        if valid.sum() < 2:
+            continue
+        vals = out[t][valid]
+        assert vals.mean().abs() < 1e-5
+
+
+def test_neutralize_cs_unit_std():
+    """cs_zscore uses population std; test with unbiased=False."""
+    p = make_synthetic_panel(SyntheticConfig(n_stocks=50, n_dates=60, seed=1))
+    out = neutralize_cs(p.close, p.mask)
+    for t in range(p.mask.shape[0]):
+        valid = p.mask[t]
+        if valid.sum() < 2:
+            continue
+        vals = out[t][valid]
+        assert torch.allclose(vals.std(unbiased=False), torch.tensor(1.0), atol=1e-5)
+
+
+def test_neutralize_cs_mask_is_zero():
+    """Masked cells remain zero."""
+    p = make_synthetic_panel(SyntheticConfig(n_stocks=30, n_dates=20, seed=2))
+    out = neutralize_cs(p.close, p.mask)
+    assert (out[~p.mask] == 0.0).all()
+
+
+def test_neutralize_cs_const_input():
+    """Constant values → zero output (no cross-sectional variation)."""
+    p = make_synthetic_panel(SyntheticConfig(n_stocks=10, n_dates=5, seed=3))
+    p.close[:] = 1.0
+    out = neutralize_cs(p.close, p.mask)
+    assert torch.allclose(out[p.mask], torch.zeros(1), atol=1e-6)
+
+
+def test_neutralize_cs_single_tradable():
+    """Single valid stock → zero (insufficient cross-section for z-score)."""
+    p = make_synthetic_panel(SyntheticConfig(n_stocks=5, n_dates=5, seed=4))
+    mask = torch.zeros_like(p.mask)
+    mask[:, 0] = True
+    out = neutralize_cs(p.close, mask)
+    assert (out == 0.0).all()
+
+
+def test_neutralize_cs_all_masked():
+    """No tradable stocks → all zero."""
+    p = make_synthetic_panel(SyntheticConfig(n_stocks=10, n_dates=5, seed=5))
+    mask = torch.zeros_like(p.mask)
+    out = neutralize_cs(p.close, mask)
+    assert (out == 0.0).all()
+
+
+def test_neutralize_cs_num_tradable_equals_one():
+    """Exactly one stock tradable each day → output zero (std=0, clamped)."""
+    p = make_synthetic_panel(SyntheticConfig(n_stocks=20, n_dates=10, seed=6))
+    mask = torch.zeros_like(p.mask)
+    for t in range(mask.shape[0]):
+        mask[t, t % mask.shape[1]] = True
+    out = neutralize_cs(p.close, mask)
+    assert (out == 0.0).all()
+
+
+def test_neutralize_cs_permutation():
+    """Stock order permutation → output permuted identically."""
+    p = make_synthetic_panel(SyntheticConfig(n_stocks=20, n_dates=10, seed=7))
+    out1 = neutralize_cs(p.close, p.mask)
+    perm = torch.randperm(p.close.shape[1])
+    out2 = neutralize_cs(p.close[:, perm], p.mask[:, perm])
+    assert torch.allclose(out1[:, perm], out2, atol=1e-5)
+
+
+# =============================================================================
+# neutralize_industry — basic properties
+# =============================================================================
+
+
+def test_neutralize_industry_mean_zero():
+    """Residuals after industry neutralisation have per-date mean≈0."""
+    p = make_synthetic_panel(SyntheticConfig(n_stocks=30, n_dates=20, seed=8))
+    onehot = _make_onehot(30, 5).expand(p.close.shape[0], -1, -1)
+    out = neutralize_industry(p.close, p.mask, onehot)
+    for t in range(p.mask.shape[0]):
+        valid = p.mask[t]
+        if valid.sum() < 3:
+            continue
+        assert out[t][valid].mean().abs() < 1e-5
+
+
+def test_neutralize_industry_orthogonal_to_industries():
+    """Residuals should be (approximately) orthogonal to industry dummies."""
+    p = make_synthetic_panel(SyntheticConfig(n_stocks=24, n_dates=10, seed=9))
+    onehot = _make_onehot(24, 4).expand(p.close.shape[0], -1, -1)
+    out = neutralize_industry(p.close, p.mask, onehot)
+    for t in range(p.mask.shape[0]):
+        valid = p.mask[t]
+        if valid.sum() < 5:
+            continue
+        X = onehot[t][valid].float()
+        r = out[t][valid].unsqueeze(1)
+        proj = (X.T @ r).abs().max()
+        assert proj < 1e-3, f"date {t}: max industry exposure {proj.item():.6f}"
+
+
+def test_neutralize_industry_orthogonal_to_size():
+    """With log_size, residuals orthogonal to size."""
+    p = make_synthetic_panel(SyntheticConfig(n_stocks=24, n_dates=10, seed=10))
+    onehot = _make_onehot(24, 4).expand(p.close.shape[0], -1, -1)
+    log_size = torch.log(p.close.abs().clamp_min(1e-12))
+    out = neutralize_industry(p.close, p.mask, onehot, log_size=log_size)
+    for t in range(p.mask.shape[0]):
+        valid = p.mask[t]
+        if valid.sum() < 6:
+            continue
+        r = out[t][valid]
+        s = log_size[t][valid]
+        # covariance between residual and size
+        cov = ((r - r.mean()) * (s - s.mean())).mean().abs()
+        assert cov < 1e-3, f"date {t}: size covariance {cov.item():.6f}"
+
+
+def test_neutralize_industry_mask_is_zero():
+    """Masked cells remain zero."""
+    p = make_synthetic_panel(SyntheticConfig(n_stocks=20, n_dates=10, seed=11))
+    onehot = _make_onehot(20, 4).expand(p.close.shape[0], -1, -1)
+    mask = p.mask.clone()
+    mask[:, :5] = False
+    out = neutralize_industry(p.close, mask, onehot)
+    assert (out[:, :5] == 0.0).all()
+
+
+# =============================================================================
+# neutralize_industry — edge cases
+# =============================================================================
+
+
+def test_neutralize_industry_insufficient_stocks():
+    """Single tradable stock → zero (OLS not possible)."""
+    p = make_synthetic_panel(SyntheticConfig(n_stocks=10, n_dates=5, seed=12))
+    onehot = _make_onehot(10, 3).expand(p.close.shape[0], -1, -1)
+    mask = torch.zeros_like(p.mask)
+    mask[:, 0] = True
+    out = neutralize_industry(p.close, mask, onehot)
+    assert (out == 0.0).all()
+
+
+def test_neutralize_industry_rank_deficient():
+    """True rank-deficient design: two identical industry columns."""
+    p = make_synthetic_panel(SyntheticConfig(n_stocks=20, n_dates=10, seed=13))
+    # create two identical dummy columns
+    onehot_single = _make_onehot(20, 3)  # [1, N, 3]
+    onehot = torch.cat([onehot_single, onehot_single[:, :, :1]], dim=-1)  # [1, N, 4], col3 == col0
+    onehot = onehot.expand(p.close.shape[0], -1, -1)
+    out = neutralize_industry(p.close, p.mask, onehot)
+    # should not crash or produce NaN
+    assert torch.isfinite(out).all()
+    for t in range(p.mask.shape[0]):
+        valid = p.mask[t]
+        if valid.sum() < 5:
+            continue
+        assert out[t][valid].mean().abs() < 1e-5
+
+
+def test_neutralize_industry_perfectly_explained():
+    """Signal perfectly explained by industries → output zero (no amplified noise).
+
+    Uses a full-rank design: each stock is in exactly one of K-1 industries
+    (plus an implicit Kth baseline group). The signal x is then x = X @ beta,
+    which is perfectly explained by the design. After neutralisation the
+    residual should be near machine precision, not amplified unit-variance noise."""
+    T, N = 10, 20
+    K = 4  # K-1 = 3 columns in design (full rank)
+    # Industry 0..K-2 each get N//K stocks; the remaining are "baseline" (all zeros)
+    X = torch.zeros(1, N, K - 1)
+    for i in range(N):
+        grp = i % K
+        if grp < K - 1:
+            X[0, i, grp] = 1.0
+    # full-rank by construction: no column is all-zeros, stock counts differ → no collinearity
+    beta = torch.tensor([1.5, -2.0, 0.7])
+    x = (X.squeeze(0) @ beta).unsqueeze(0).expand(T, -1)
+    mask = torch.ones(T, N, dtype=torch.bool)
+    onehot_expanded = X.expand(T, -1, -1)
+    out = neutralize_industry(x, mask, onehot_expanded)
+    assert out.abs().max() < 1e-4, f"max residual: {out.abs().max().item():.6e}"
+
+
+def test_neutralize_industry_perfectly_explained_with_size():
+    """Signal = industry*beta + size*gamma → output zero (perfectly explained)."""
+    T, N = 10, 20
+    K = 4
+    X = torch.zeros(1, N, K - 1)
+    for i in range(N):
+        grp = i % K
+        if grp < K - 1:
+            X[0, i, grp] = 1.0
+    size = torch.randn(1, N).expand(T, -1)
+    beta = torch.tensor([1.5, -2.0, 0.7])
+    gamma = 3.0
+    x = (X.squeeze(0) @ beta).unsqueeze(0).expand(T, -1) + gamma * size
+    mask = torch.ones(T, N, dtype=torch.bool)
+    onehot_expanded = X.expand(T, -1, -1)
+    out = neutralize_industry(x, mask, onehot_expanded, log_size=size)
+    assert out.abs().max() < 1e-4, f"max residual: {out.abs().max().item():.6e}"
+
+
+def test_neutralize_industry_std_normalized():
+    """Non-degenerate residuals have unit population std."""
+    p = make_synthetic_panel(SyntheticConfig(n_stocks=30, n_dates=20, seed=16))
+    onehot = _make_onehot(30, 5).expand(p.close.shape[0], -1, -1)
+    out = neutralize_industry(p.close, p.mask, onehot)
+    for t in range(p.mask.shape[0]):
+        valid = p.mask[t]
+        if valid.sum() < 3:
+            continue
+        vals = out[t][valid]
+        # population std ≈ 1 after z-scoring (atol 0.02 accounts for regression residual noise)
+        assert torch.allclose(vals.std(unbiased=False), torch.tensor(1.0), atol=0.02), \
+            f"date {t}: std {vals.std(unbiased=False).item():.6f}"
+
+
+# =============================================================================
+# neutralize — shape / dtype / device
+# =============================================================================
+
+
+def test_neutralize_cs_dtype():
+    """float32 input → float32 output."""
+    p = make_synthetic_panel(SyntheticConfig(n_stocks=10, n_dates=5, seed=17))
+    out = neutralize_cs(p.close.float(), p.mask)
+    assert out.dtype == torch.float32
+
+
+def test_neutralize_industry_dtype():
+    """float32 input → float32 output."""
+    p = make_synthetic_panel(SyntheticConfig(n_stocks=10, n_dates=5, seed=18))
+    onehot = _make_onehot(10, 3).expand(5, -1, -1)
+    out = neutralize_industry(p.close.float(), p.mask, onehot.float())
+    assert out.dtype == torch.float32
+
+
+def test_neutralize_cs_shape():
+    """Output shape matches input."""
+    p = make_synthetic_panel(SyntheticConfig(n_stocks=15, n_dates=8, seed=19))
+    out = neutralize_cs(p.close, p.mask)
+    assert out.shape == p.close.shape
+
+
+def test_neutralize_industry_shape():
+    """Output shape matches input."""
+    p = make_synthetic_panel(SyntheticConfig(n_stocks=15, n_dates=8, seed=20))
+    onehot = _make_onehot(15, 3).expand(8, -1, -1)
+    out = neutralize_industry(p.close, p.mask, onehot)
+    assert out.shape == p.close.shape

--- a/tests/test_public_data_validation.py
+++ b/tests/test_public_data_validation.py
@@ -5,6 +5,7 @@ from scripts.public_data_validation import (
     ValidationConfig,
     _cost_sensitivity_table,
     _markdown_table,
+    _select_tickers,
     run_validation,
 )
 
@@ -89,6 +90,34 @@ def test_public_data_validation_markdown_escapes_pipes():
     )
 
     assert "alpha \\| beta" in table
+
+
+def test_select_tickers_preserves_baostock_case():
+    """baostock tickers must not be uppercased: sh.600000 → SH.600000 breaks the loader."""
+    tickers = _select_tickers(
+        "cn-large-25",
+        "sh.600000,sz.000001",
+        10,
+        source="baostock",
+    )
+    assert tickers == ("sh.600000", "sz.000001")
+
+
+def test_select_tickers_uppercases_yfinance():
+    """yfinance tickers are uppercased as before."""
+    tickers = _select_tickers(
+        "us-large-100",
+        "aapl,msft",
+        10,
+        source="yfinance",
+    )
+    assert tickers == ("AAPL", "MSFT")
+
+
+def test_select_tickers_preset_fallback():
+    """Preset fallback works for baostock source."""
+    tickers = _select_tickers("cn-large-25", "", 10, source="baostock")
+    assert tickers[:2] == ("sh.600000", "sh.600036")
 
 
 def test_public_data_validation_cost_table_escapes_pipes():


### PR DESCRIPTION
## What changed

This revision rebases the contribution onto the current `main` and keeps only the new fixes beyond #33 and #34.

- use a scale-relative degeneracy guard in industry neutralization, avoiding amplified float32 noise without suppressing genuinely small signals
- expand neutralization tests for orthogonality, rank-deficient designs, perfect fits, small-scale signals, masks, shapes, and dtypes
- keep Baostock VWAP consistent with forward-adjusted OHLC through the typical-price proxy
- reject unavailable raw VWAP explicitly instead of mixing adjusted and unadjusted data
- normalize and validate complete `sh./sz.` ticker codes with regression tests

The previously merged Baostock report, dependency declarations, and CLI integration remain unchanged.