### PR TITLE
docs: refresh contributor and outreach links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 > **Machine Learning Enhanced Multi-Factor Quantitative Trading**
 > — A Cross-Sectional Portfolio Optimization Approach with Bias Correction
 >
-> [arXiv:2507.07107](https://arxiv.org/abs/2507.07107) &nbsp;|&nbsp; Yimin Du, 2025
+> [arXiv:2507.07107](https://arxiv.org/abs/2507.07107) &nbsp;|&nbsp;
+> [Hugging Face Papers](https://huggingface.co/papers/2507.07107) &nbsp;|&nbsp; Yimin Du, 2025
 
 [![CI](https://github.com/initial-d/ml-quant-trading/actions/workflows/ci.yml/badge.svg)](https://github.com/initial-d/ml-quant-trading/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/initial-d/ml-quant-trading?display_name=tag)](https://github.com/initial-d/ml-quant-trading/releases)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ research pipeline.
 - Read the [Research Card](docs/research_card.md) for intended use, current evidence, and non-goals.
 - Read the [public-data mini reproduction](docs/public_data_mini_reproduction.md).
 - Share benchmark or public-data results in [Discussions #13](https://github.com/initial-d/ml-quant-trading/discussions/13).
-- Pick up a newcomer task: [more benchmark reports](https://github.com/initial-d/ml-quant-trading/issues/7) or an [ETF/larger-universe public-data reproduction](https://github.com/initial-d/ml-quant-trading/issues/16).
+- Pick up a newcomer task: [more benchmark reports](https://github.com/initial-d/ml-quant-trading/issues/7) or a [paired public-data validation or benchmark contribution](https://github.com/initial-d/ml-quant-trading/issues/22).
 - Read the [Reality Check and Validation Status](docs/reality_check.md) before interpreting any backtest as evidence of deployable alpha.
 
 > **Research and educational use only.** This project is not investment

--- a/docs/community_outreach.md
+++ b/docs/community_outreach.md
@@ -16,13 +16,18 @@ Post only where you already have an account and can reply to comments.
 | Channel | Angle | Suggested ask |
 |---|---|---|
 | GitHub Issues / Discussions | Project launch and benchmark call | Submit CPU/GPU benchmark results |
+| Hugging Face Papers | Paper and reproducibility artifacts | Try the public-data and synthetic reproduction paths |
+| Awesome Quant | Curated open-source discovery | Evaluate the documented research stack |
+| Hacker News Show HN | Runnable open-source research stack | Run the quick start and critique the design |
+| QuantConnect forum | Reproducible factor and backtest research | Compare assumptions and public-data results |
 | LinkedIn | Research software announcement | Feedback from quant/ML engineers |
 | X / Twitter | Short technical launch | Star, benchmark, or try notebook |
-| Reddit r/algotrading | Practical backtesting/factor pipeline | Reproducibility and caveat feedback |
-| Reddit r/quant | Research baseline | Public-data reproduction feedback |
-| Hacker News Show HN | Open-source research stack | Try quick start and critique design |
 | Quant StackExchange chat / communities | Factor-engine discussion | Edge cases and assumptions |
 | University quant clubs | Student-friendly baseline | Run Start Here and report issues |
+
+Reddit communities often remove direct repository promotion. Share there only when a
+substantive, self-contained technical write-up is allowed by the current community rules;
+the repository link should support the analysis rather than be the purpose of the post.
 
 ## Short Post
 
@@ -71,4 +76,5 @@ Paper: https://arxiv.org/abs/2507.07107
 - Disclose limitations clearly.
 - Do not imply live trading profitability.
 - Do not ask directly for stars before asking for useful feedback.
+- Verify the current community rules before posting, especially for self-promotion.
 - Reply to comments and convert repeated questions into docs.

--- a/docs/start_here.md
+++ b/docs/start_here.md
@@ -118,7 +118,7 @@ Good current entry points:
 
 - [Collect community CPU/GPU benchmark results](https://github.com/initial-d/ml-quant-trading/issues/7)
 - [Share benchmark and public-data reproductions](https://github.com/initial-d/ml-quant-trading/issues/12)
-- [Add an ETF or larger-universe public-data reproduction](https://github.com/initial-d/ml-quant-trading/issues/16)
+- [Pair on a public-data validation or benchmark contribution](https://github.com/initial-d/ml-quant-trading/issues/22)
 
 ## 6. What Not to Expect
 

--- a/docs/visibility_status.md
+++ b/docs/visibility_status.md
@@ -6,6 +6,7 @@ This page tracks the current public launch surface for `ml-quant-trading`.
 
 - Repository: <https://github.com/initial-d/ml-quant-trading>
 - Paper: <https://arxiv.org/abs/2507.07107>
+- Hugging Face paper page: <https://huggingface.co/papers/2507.07107>
 - alphaXiv page: <https://www.alphaxiv.org/abs/2507.07107>
 - v0.1.0 release: <https://github.com/initial-d/ml-quant-trading/releases/tag/v0.1.0>
 - Benchmark and reproduction discussion: <https://github.com/initial-d/ml-quant-trading/discussions/13>

--- a/docs/visibility_status.md
+++ b/docs/visibility_status.md
@@ -10,16 +10,23 @@ This page tracks the current public launch surface for `ml-quant-trading`.
 - v0.1.0 release: <https://github.com/initial-d/ml-quant-trading/releases/tag/v0.1.0>
 - Benchmark and reproduction discussion: <https://github.com/initial-d/ml-quant-trading/discussions/13>
 - Benchmark call issue: <https://github.com/initial-d/ml-quant-trading/issues/12>
+- Pairing and public-data validation issue: <https://github.com/initial-d/ml-quant-trading/issues/22>
 - GitHub Community post: <https://github.com/orgs/community/discussions/201001>
 - v0.2.0 community benchmark milestone: <https://github.com/initial-d/ml-quant-trading/milestone/1>
 - Dev Container setup: `.devcontainer/devcontainer.json`
 
-## Current Contributor Funnel
+## Completed Contributor Milestones
 
 - First real-machine tensor benchmark report: <https://github.com/initial-d/ml-quant-trading/issues/15>
 - Public-data mini reproduction note: <https://github.com/initial-d/ml-quant-trading/issues/14>
 - First-run onboarding feedback: <https://github.com/initial-d/ml-quant-trading/issues/10>
 - Public-data mini reproduction doc: <https://github.com/initial-d/ml-quant-trading/blob/main/docs/public_data_mini_reproduction.md>
+
+## Current Contributor Funnel
+
+- Community CPU/GPU benchmarks: <https://github.com/initial-d/ml-quant-trading/issues/7>
+- Paired public-data validation and benchmark work: <https://github.com/initial-d/ml-quant-trading/issues/22>
+- Benchmark and reproduction reports: <https://github.com/initial-d/ml-quant-trading/discussions/13>
 
 ## Current Positioning
 
@@ -46,5 +53,7 @@ Primary ask:
 - Add more public-data mini reproductions with larger or differently constructed universes.
 - Ask new users to try the Dev Container and report first-run friction.
 - Post the v0.1.0 release to one relevant community at a time with a customized note.
+- Submit the paper to Hugging Face Papers and link the repository and reproduction paths.
+- Propose the repository for the Awesome Quant curated list.
 - Set a GitHub social preview image through repository settings when browser upload access is available.
 - Convert useful discussion replies into docs, issues, or benchmark board entries.


### PR DESCRIPTION
## Summary

- replace the closed public-data issue link with the active pairing workflow
- separate completed contributor milestones from current contribution entry points
- add Hugging Face Papers, Awesome Quant, Show HN, and QuantConnect as targeted outreach channels
- document the self-promotion risk for Reddit communities

## Why

The README and Start Here guide still pointed newcomers to closed issue #16, while the outreach docs did not reflect the contributor flow that is currently active in #22.

## Validation

- `git diff --check`
- verified there are no remaining references to issue #16 in README/docs/community files