### PR TITLE
docs: add GitHub profile growth notes

### DIFF
--- a/docs/github_profile_growth.md
+++ b/docs/github_profile_growth.md
@@ -1,0 +1,34 @@
+# GitHub Profile Growth Notes
+
+This note keeps profile growth work aligned with the repository's
+validation-first posture. The goal is to earn GitHub profile achievements through
+real maintenance, reproducibility work, and useful community participation.
+
+## Healthy Achievement Paths
+
+| Achievement | Healthy route | Notes |
+|---|---|---|
+| Pull Shark | Merge real pull requests | Prefer docs, tests, benchmark reports, and external list PRs. |
+| Galaxy Brain | Answer real questions in GitHub Discussions | Prioritize accepted answers that solve the user's problem. |
+| Quickdraw | Close a real issue quickly after a small scoped fix | The issue should track real work, not an empty placeholder. |
+| YOLO | Merge a low-risk maintainer PR without review | Use only for safe docs or metadata changes. |
+| Starstruck | Build public projects people want to star | The sustainable path is releases, examples, and reproducible reports. |
+| Pair Extraordinaire | Merge real co-authored PRs | Requires an actual collaborator, not fabricated co-authorship. |
+
+## Operating Rules
+
+- Do not buy stars, forks, comments, follows, or accepted answers.
+- Do not open empty PRs or issues only to trigger achievements.
+- Prefer small release notes, validation reports, benchmark submissions, and
+  external documentation PRs.
+- Follow up where maintainers reply; avoid repeated pings on stale PRs.
+- Keep public claims tied to reproducible commands, data-source notes, and known
+  limitations.
+
+## Current Best Bets
+
+- Continue merging contributor benchmark or validation PRs.
+- Keep answering high-signal Q&A around backtesting, public data, PyTorch, and
+  factor validation.
+- Invite real co-authored validation reports for Pair Extraordinaire progress.
+- Improve examples and release notes so Starstruck growth comes from real users.


### PR DESCRIPTION
Closes #40

Adds a short maintainer note for healthy GitHub profile growth:

- achievement paths that map to real work;
- operating rules against spam or fake engagement;
- next best bets for benchmark reports, accepted answers, and co-authored validation work.