### PR TITLE
feat: add akshare data loader for zero-auth A-share OHLCV panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,14 @@ If you build on this work, please consider citing the paper and opening issues o
 
 | Source | Market | Access | Notes |
 |--------|--------|--------|-------|
+| [AkShare](https://akshare.akfamily.xyz/) | A-shares | Public, no API key | Zero-auth loader backed by public upstream interfaces that may change or rate-limit |
 | [Baostock](http://baostock.com) | A-shares | Free registration | Supported A-share loader; requires account |
 | [yfinance](https://pypi.org/project/yfinance/) | US equities / ETFs | Public, rate-limited | Used for public-data validation and cross-market examples |
 | Synthetic | N/A | Zero-config | Deterministic GBM panel for smoke testing the pipeline |
 
-The repository does not redistribute market data. Baostock and yfinance data
-are downloaded on-demand by the loader scripts. Synthetic data is generated
+The repository does not redistribute market data. AkShare, Baostock, and
+yfinance data are downloaded on-demand by the loader scripts. Public upstream
+interfaces can change or rate-limit requests. Synthetic data is generated
 deterministically from a fixed seed.
 
 ## Quick Start
@@ -262,7 +264,7 @@ stock_019  stock_020  stock_021  stock_022
 
 ### Data Sources
 
-You can directly fetch stock data from Yahoo Finance or Baostock (for A-shares).
+You can directly fetch stock data from Yahoo Finance, Baostock, or AkShare.
 
 **yfinance:**
 ```python
@@ -288,6 +290,22 @@ panel = make_panel(
 )
 ```
 
+**AkShare (A-shares, no API key):**
+```python
+from mlquant.data import make_panel
+
+panel = make_panel(
+    source="akshare",
+    tickers=["600519", "000001"],
+    start="2020-01-01",
+    end="2023-12-31",
+    adjust="qfq",
+)
+```
+
+AkShare uses public upstream interfaces, so availability, schemas, and rate
+limits can change independently of this project.
+
 ### Usage
 
 ```python
@@ -307,7 +325,7 @@ factors, mask, names = compute_legacy_set(panel, names=("best_001", "add_015", "
 ```mermaid
 flowchart LR
     subgraph Data["1. Data"]
-        A[Raw OHLCV] --> B[loaders<br/>synthetic / yfinance / baostock]
+        A[Raw OHLCV] --> B[loaders<br/>synthetic / yfinance / baostock / akshare]
     end
     subgraph Features["2. Features"]
         B --> C[tensor_factors<br/>GPU masked primitives]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "tqdm>=4.65",
     "yfinance>=0.2.0",
     "baostock>=0.8.8",
+    "akshare>=1.18.0",
 ]
 
 [project.optional-dependencies]

--- a/src/mlquant/data/__init__.py
+++ b/src/mlquant/data/__init__.py
@@ -4,15 +4,21 @@ The package treats market data as a pair of ``[date, stock]`` torch
 tensors plus a boolean mask telling us which cells are tradable. All
 downstream code (factors, training, portfolio) operates on this layout.
 
-Two data sources are wired up out of the box:
+Five data sources are wired up out of the box:
 
 * ``"synthetic"`` — :func:`make_synthetic_panel`, deterministic GBM panel
   for tests, demos and CI.
 * ``"csv"`` — :func:`load_ochlv_csv`, generic tab-separated Wind / Tushare
   dump with optional ``LIMIT_UP`` / ``LIMIT_DOWN`` / ``LAST_CLOSE`` /
   ``S_DQ_AMOUNT`` columns.
+* ``"yfinance"`` — :func:`load_yfinance_panel`, public Yahoo Finance
+  market data.
+* ``"baostock"`` — :func:`load_baostock_panel`, authenticated A-share
+  daily data.
+* ``"akshare"`` — :func:`load_akshare_panel`, zero-auth A-share daily
+  data from public upstream interfaces.
 
-Both return the same :class:`Panel`, so consumers should never branch
+All return the same :class:`Panel`, so consumers should never branch
 on the source.
 """
 from __future__ import annotations
@@ -40,13 +46,13 @@ __all__ = [
 
 
 def make_panel(source: str = "synthetic", **kwargs: Any) -> Panel:
-    """Unified factory: ``make_panel("synthetic", ...)`` or ``make_panel("csv", path=...)``.
+    """Build a panel from synthetic, CSV, yfinance, Baostock, or AkShare data.
 
     Parameters
     ----------
     source : str
-        Either ``"synthetic"`` (forwarded to :class:`SyntheticConfig`) or
-        ``"csv"`` (forwarded to :func:`load_ochlv_csv`).
+        One of ``"synthetic"``, ``"csv"``, ``"yfinance"``,
+        ``"baostock"``, or ``"akshare"``.
     **kwargs
         Source-specific keyword arguments.
     """

--- a/src/mlquant/data/__init__.py
+++ b/src/mlquant/data/__init__.py
@@ -25,6 +25,7 @@ from .synthetic import SyntheticConfig, make_synthetic_panel
 from .loaders import load_ochlv_csv
 from .yfinance_loader import load_yfinance_panel
 from .baostock_loader import load_baostock_panel
+from .akshare_loader import load_akshare_panel
 
 __all__ = [
     "Panel",
@@ -33,6 +34,7 @@ __all__ = [
     "load_ochlv_csv",
     "load_yfinance_panel",
     "load_baostock_panel",
+    "load_akshare_panel",
     "make_panel",
 ]
 
@@ -70,4 +72,11 @@ def make_panel(source: str = "synthetic", **kwargs: Any) -> Panel:
         if tickers is None or start is None or end is None:
             raise TypeError("make_panel(source='baostock', ...) requires `tickers`, `start`, and `end` kwargs")
         return load_baostock_panel(tickers, start, end, **kwargs)
+    if source == "akshare":
+        tickers = kwargs.pop("tickers", None)
+        start = kwargs.pop("start", None)
+        end = kwargs.pop("end", None)
+        if tickers is None or start is None or end is None:
+            raise TypeError("make_panel(source='akshare', ...) requires `tickers`, `start`, and `end` kwargs")
+        return load_akshare_panel(tickers, start, end, **kwargs)
     raise ValueError(f"unknown panel source: {source!r}")

--- a/src/mlquant/data/akshare_loader.py
+++ b/src/mlquant/data/akshare_loader.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import numpy as np
+import pandas as pd
+import torch
+
+from .panel import Panel
+
+
+def load_akshare_panel(
+    tickers: Sequence[str],
+    start: str,
+    end: str,
+    device: Union[str, torch.device] = "cpu",
+    adjust: str = "qfq",
+    proxy_vwap: bool = True,
+) -> Panel:
+    """Download A-share daily data from akshare and return a Panel.
+
+    Parameters
+    ----------
+    tickers : Sequence[str]
+        A-share ticker codes without exchange prefixes (for example, "600519").
+    start : str
+        Start date in "YYYY-MM-DD" format.
+    end : str
+        End date in "YYYY-MM-DD" format.
+    device : str or torch.device
+        Where to allocate the resulting tensors.
+    adjust : str
+        Price adjustment mode: "qfq", "hfq", or an empty string.
+    proxy_vwap : bool
+        If True, estimate VWAP as (Open + Close + High + Low) / 4.
+    """
+    import akshare
+
+    if not tickers:
+        raise ValueError("Tickers list cannot be empty")
+
+    # 按输入顺序去重，避免下载和透视时产生重复列
+    unique_tickers = list(dict.fromkeys(tickers))
+
+    if not proxy_vwap:
+        raise ValueError(
+            "akshare cannot provide an adjustment-consistent raw VWAP; use proxy_vwap=True"
+        )
+
+    column_map = {
+        "日期": "date",
+        "开盘": "open",
+        "收盘": "close",
+        "最高": "high",
+        "最低": "low",
+        "成交量": "volume",
+        "成交额": "amount",
+    }
+    data_columns = ["date", "open", "high", "low", "close", "volume", "amount"]
+
+    all_data = []
+    for ticker in unique_tickers:
+        try:
+            ticker_df = akshare.stock_zh_a_hist(
+                symbol=ticker,
+                period="daily",
+                start_date=start.replace("-", ""),
+                end_date=end.replace("-", ""),
+                adjust=adjust,
+            )
+            if ticker_df is None or ticker_df.empty:
+                continue
+
+            ticker_df = ticker_df.rename(columns=column_map)
+            missing_columns = [column for column in data_columns if column not in ticker_df.columns]
+            if missing_columns:
+                raise ValueError(f"missing columns: {missing_columns}")
+
+            ticker_df = ticker_df[data_columns].copy()
+            ticker_df["code"] = ticker
+            all_data.append(ticker_df)
+        except Exception as e:
+            print(f"Warning: Failed to fetch {ticker}: {e}")
+            continue
+
+    if not all_data:
+        raise ValueError(
+            f"No data returned for tickers {unique_tickers} from {start} to {end}"
+        )
+
+    df = pd.concat(all_data, ignore_index=True)
+
+    # 将行情字段统一转为数值类型
+    num_cols = ["open", "high", "low", "close", "volume", "amount"]
+    for col in num_cols:
+        df[col] = pd.to_numeric(df[col], errors="coerce")
+
+    df["date"] = pd.to_datetime(df["date"])
+
+    # 将长表转换为日期乘股票的宽表
+    fields_wide = {}
+
+    def get_wide_df(col_name):
+        wide = df.pivot(index="date", columns="code", values=col_name)
+        # 为所有请求的股票补齐列，并保持原始顺序
+        for ticker in unique_tickers:
+            if ticker not in wide.columns:
+                wide[ticker] = np.nan
+        return wide[list(unique_tickers)]
+
+    open_df = get_wide_df("open")
+    high_df = get_wide_df("high")
+    low_df = get_wide_df("low")
+    close_df = get_wide_df("close")
+    volume_df = get_wide_df("volume")
+    amount_df = get_wide_df("amount")
+
+    fields_wide["open"] = open_df
+    fields_wide["high"] = high_df
+    fields_wide["low"] = low_df
+    fields_wide["close"] = close_df
+    fields_wide["volume"] = volume_df
+    fields_wide["amount"] = amount_df
+    fields_wide["vwap"] = (open_df + close_df + high_df + low_df) / 4.0
+
+    dates = open_df.index.to_numpy()
+    stocks = list(unique_tickers)
+
+    mask = (
+        ~open_df.isna()
+        & ~high_df.isna()
+        & ~low_df.isna()
+        & ~close_df.isna()
+        & ~volume_df.isna()
+    ).to_numpy()
+
+    tensors = {
+        name: torch.from_numpy(df_.fillna(0.0).to_numpy(dtype=np.float32).copy()).to(device)
+        for name, df_ in fields_wide.items()
+    }
+
+    return Panel.from_tensors(
+        dates=dates,
+        stocks=stocks,
+        fields=tensors,
+        mask=torch.from_numpy(mask.copy()).to(device),
+    )

--- a/tests/test_akshare.py
+++ b/tests/test_akshare.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import unittest.mock as mock
+
+import pandas as pd
+import pytest
+import torch
+
+from mlquant.data.akshare_loader import load_akshare_panel
+
+
+def test_load_akshare_panel_mock():
+    # 构造包含 akshare 真实中文列名的模拟数据
+    def make_mock_df(*, symbol, period, start_date, end_date, adjust):
+        assert symbol in {"600519", "000001"}
+        assert period == "daily"
+        assert start_date == "20230101"
+        assert end_date == "20230104"
+        assert adjust == "qfq"
+        return pd.DataFrame(
+            {
+                "日期": ["2023-01-03", "2023-01-04"],
+                "开盘": [10.0, 10.5],
+                "收盘": [10.5, 11.5],
+                "最高": [11.0, 12.0],
+                "最低": [9.0, 10.0],
+                "成交量": [1000, 2000],
+                "成交额": [10000, 22000],
+                "振幅": [20.0, 19.0],
+                "涨跌幅": [5.0, 9.5],
+                "涨跌额": [0.5, 1.0],
+                "换手率": [1.0, 2.0],
+            }
+        )
+
+    with mock.patch("akshare.stock_zh_a_hist") as mock_hist:
+        mock_hist.side_effect = make_mock_df
+
+        tickers = ["600519", "000001", "600519"]  # 包含重复代码
+        panel = load_akshare_panel(tickers, "2023-01-01", "2023-01-04")
+
+        # 去重后只调用两次 akshare
+        assert mock_hist.call_count == 2
+
+        # 检查 Panel 维度和股票顺序
+        assert panel.n_stocks == 2
+        assert panel.n_dates == 2
+        assert list(panel.stocks) == ["600519", "000001"]
+
+        expected_close = torch.tensor(
+            [[10.5, 10.5], [11.5, 11.5]], dtype=torch.float32
+        )
+        assert torch.allclose(panel.close, expected_close)
+
+        expected_vwap = torch.tensor(
+            [[10.125, 10.125], [11.0, 11.0]], dtype=torch.float32
+        )
+        assert torch.allclose(panel.vwap, expected_vwap)
+
+        assert panel.mask.all()
+
+
+def test_load_akshare_panel_empty_tickers():
+    with pytest.raises(ValueError, match="Tickers list cannot be empty"):
+        load_akshare_panel([], "2023-01-01", "2023-01-04")

--- a/tests/test_akshare.py
+++ b/tests/test_akshare.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 import torch
 
+from mlquant.data import make_panel
 from mlquant.data.akshare_loader import load_akshare_panel
 
 
@@ -63,3 +64,23 @@ def test_load_akshare_panel_mock():
 def test_load_akshare_panel_empty_tickers():
     with pytest.raises(ValueError, match="Tickers list cannot be empty"):
         load_akshare_panel([], "2023-01-01", "2023-01-04")
+
+
+def test_make_panel_dispatches_to_akshare():
+    expected_panel = mock.sentinel.panel
+    with mock.patch("mlquant.data.load_akshare_panel", return_value=expected_panel) as loader:
+        panel = make_panel(
+            source="akshare",
+            tickers=["600519", "000001"],
+            start="2023-01-01",
+            end="2023-01-04",
+            adjust="hfq",
+        )
+
+    assert panel is expected_panel
+    loader.assert_called_once_with(
+        ["600519", "000001"],
+        "2023-01-01",
+        "2023-01-04",
+        adjust="hfq",
+    )


### PR DESCRIPTION
## 做了什么

新增 `akshare` 数据源加载器，让 ml-quant 支持通过 akshare（东方财富底层）获取 A 股日线 OHLCV 数据，无需注册或 API Key。

## 改动范围

| 文件 | 操作 |
|------|------|
| `src/mlquant/data/akshare_loader.py` | 新建 — akshare → Panel 加载器，148 行 |
| `src/mlquant/data/__init__.py` | 修改 — 导出 + `make_panel(source="akshare")` |
| `tests/test_akshare.py` | 新建 — mock 测试，覆盖中文列名解析/去重/VWAP/mask |
| `pyproject.toml` | 修改 — 加 `akshare>=1.18.0` |

## 设计决策

**完全照搬既有 loader 模式**——函数签名、错误处理、宽表转换、mask 构建均与 `baostock_loader.py` 一致，新增代码不引入新的抽象层。

**和 baostock loader 的关键差异**：
- 无需 `login()`/`logout()`（akshare 零认证）
- 代码格式为纯数字（`"600519"` 而非 `"sh.600000"`）
- mask 用 OHLCV 完整性判断（akshare 无显式 `tradestatus` 字段）
- VWAP 始终用 `(O+C+H+L)/4` 代理——与 baostock v0.2.0 修复后的策略一致（akshare 复权后的 amount/volume 与 OHLC 不同基准）

## 使用方式

```python
from mlquant.data import make_panel

panel = make_panel(
    "akshare",
    tickers=["600519", "000001"],
    start="2023-01-01",
    end="2023-12-31",
    adjust="qfq",              # 可选，默认前复权
)
```

## 验收

```
$ python -m pytest tests/test_akshare.py tests/test_baostock.py -v
5 passed

$ python -m pytest
47 passed

$ ruff check src/mlquant/data/akshare_loader.py tests/test_akshare.py
All checks passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: GPT-5.6-Sol (via Codex CLI) <noreply@anthropic.com>