### PR TITLE
Launch August reproducibility challenge

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ Languages: [English](README.md) | [简体中文](README.zh-CN.md) | [繁體中�
 [**Run in Colab**](https://colab.research.google.com/github/initial-d/ml-quant-trading/blob/main/notebooks/quickstart_colab.ipynb)
 · [**See validated results**](docs/validation_dashboard.md)
 · [**Read the paper**](https://arxiv.org/abs/2507.07107)
-· [**Join the discussion**](https://github.com/initial-d/ml-quant-trading/discussions/13)
+· [**Join the August reproduction challenge**](https://github.com/initial-d/ml-quant-trading/discussions/43)
+
+> **August 2026 reproduction challenge:** run the zero-account Colab once and
+> post its generated report, environment, and commit SHA in
+> [Discussion #43](https://github.com/initial-d/ml-quant-trading/discussions/43).
+> Successful and failed runs are both useful. Verifiable reports will be credited
+> in the Community Evidence section.
 
 ---
 
@@ -47,7 +53,7 @@ demos, CI, tests, and benchmark tooling.
 | Run a larger validation | [Public-Data Validation](docs/public_data_validation.md) | Walk-forward baselines, costs, turnover, bootstrap CIs, and report artifacts |
 | Run A-share validation | [AkShare CSI 300 Report](docs/validation_akshare_csi300_20260729.md) | Zero-auth A-share validation on the current CSI 300 public universe |
 | Run paper-style public validation | [AkShare CSI 300 Daily 213-Factor Report](docs/validation_akshare_csi300_full_pipeline_20260729.md) | Daily 213-factor public-data approximation with turnover control |
-| Contribute results | [Benchmark discussion](https://github.com/initial-d/ml-quant-trading/discussions/13) | A place to share benchmark and reproduction reports |
+| Contribute one run | [August reproduction challenge](https://github.com/initial-d/ml-quant-trading/discussions/43) | Run Colab, post the generated report, and receive README credit |
 
 ## Validation Dashboard
 
@@ -88,6 +94,7 @@ research pipeline.
 
 **Current calls for contributors**
 
+- Join the [August 2026 reproduction challenge](https://github.com/initial-d/ml-quant-trading/discussions/43): one Colab run, one generated report, success or failure.
 - Try the [`v0.2.3` release](https://github.com/initial-d/ml-quant-trading/releases/tag/v0.2.3).
 - Read the [Research Card](docs/research_card.md) for intended use, current evidence, and non-goals.
 - Read the [public-data mini reproduction](docs/public_data_mini_reproduction.md).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,7 +18,11 @@ Languages: [English](README.md) | [简体中文](README.zh-CN.md) | [繁體中�
 [**Colab 在线运行**](https://colab.research.google.com/github/initial-d/ml-quant-trading/blob/main/notebooks/quickstart_colab.ipynb)
 · [**查看公开验证结果**](docs/validation_dashboard.md)
 · [**阅读论文**](https://arxiv.org/abs/2507.07107)
-· [**参与讨论**](https://github.com/initial-d/ml-quant-trading/discussions/13)
+· [**参加 8 月复现挑战**](https://github.com/initial-d/ml-quant-trading/discussions/43)
+
+> **2026 年 8 月复现挑战：**打开零账号 Colab 跑一次，把自动生成的报告、
+> 运行环境和 commit SHA 发布到 [Discussion #43](https://github.com/initial-d/ml-quant-trading/discussions/43)。
+> 成功和失败结果都欢迎；符合可验证性要求的报告会署名加入下方社区验证区。
 
 ## 项目概述
 
@@ -32,7 +36,7 @@ Languages: [English](README.md) | [简体中文](README.zh-CN.md) | [繁體中�
 | 不安装直接体验 | [Google Colab](https://colab.research.google.com/github/initial-d/ml-quant-trading/blob/main/notebooks/quickstart_colab.ipynb) | 无需账号或行情 API 的浏览器内完整 Demo |
 | 查看真实公开数据结果 | [CSI 300 验证看板](docs/validation_dashboard.md) | 成本敏感性、换手率、基线与复现命令 |
 | 理解研究结论边界 | [Research Card](docs/research_card.md) | 适用范围、非目标、数据假设与已知限制 |
-| 贡献复现或跑分 | [Discussions #13](https://github.com/initial-d/ml-quant-trading/discussions/13) | 分享 CPU/GPU benchmark 和公开数据报告 |
+| 贡献一次运行结果 | [8 月复现挑战](https://github.com/initial-d/ml-quant-trading/discussions/43) | 跑 Colab、提交自动报告并获得 README 署名 |
 
 ## 当前公开验证
 
@@ -52,6 +56,7 @@ Languages: [English](README.md) | [简体中文](README.zh-CN.md) | [繁體中�
 
 这些结果链接到原始 PR，便于检查环境、命令、限制和评审过程。你也可以
 [打开零账号 Colab，运行并提交生成的报告](https://colab.research.google.com/github/initial-d/ml-quant-trading/blob/main/notebooks/quickstart_colab.ipynb)。
+本月结果统一提交到 [2026 年 8 月复现挑战](https://github.com/initial-d/ml-quant-trading/discussions/43)。
 
 ## 研究与教学用途声明
 


### PR DESCRIPTION
## What changed

- adds a single, prominent August reproduction-challenge CTA to the English and Simplified Chinese READMEs
- links the README onboarding flow to Discussion #43
- promises README credit only for reports with an environment and commit SHA

## Why

Recent traffic shows strong clone activity. This gives first-time users one concrete path from trying the project to contributing verifiable community evidence, without using exaggerated return claims.

## Validation

- `git diff --check`
- Discussion #43 is live and publicly accessible

Closes no issue.