### PR TITLE
Add structured reproduction report flow

### DIFF
--- a/.github/ISSUE_TEMPLATE/reproduction_report.yml
+++ b/.github/ISSUE_TEMPLATE/reproduction_report.yml
@@ -1,0 +1,87 @@
+name: Colab reproduction report
+description: Share a successful or failed zero-account Colab or local demo run.
+title: "[reproduction] "
+labels: ["reproducibility", "community"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for running the project. Successful and failed runs are equally
+        useful. Complete this form from the same session when possible; accepted
+        reports may be credited in the README Community Evidence section.
+
+  - type: dropdown
+    id: outcome
+    attributes:
+      label: Outcome
+      description: Did the zero-account Colab or local `mlquant demo` finish?
+      options:
+        - Successful run
+        - Failed run
+        - Successful with warnings
+    validations:
+      required: true
+
+  - type: input
+    id: commit
+    attributes:
+      label: Commit SHA
+      description: Paste the commit printed by the notebook, or run `git rev-parse --short HEAD` locally.
+      placeholder: 2bc2897
+    validations:
+      required: true
+
+  - type: dropdown
+    id: entrypoint
+    attributes:
+      label: Entrypoint
+      options:
+        - Google Colab quickstart
+        - Local `mlquant demo`
+        - Other documented reproduction
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include the runtime, Python and PyTorch versions, plus CPU/GPU details shown by the notebook or local environment.
+      placeholder: |
+        Runtime: Google Colab / local OS
+        Python:
+        PyTorch:
+        CPU:
+        GPU:
+        CUDA available:
+    validations:
+      required: true
+
+  - type: textarea
+    id: report
+    attributes:
+      label: Generated report or failure output
+      description: Paste `artifacts/small/summary.md`. For failures, paste the shortest useful error and the cell or command that failed.
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Mention warnings, local changes, retries, or anything that would help another user reproduce your result.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: Submission checks
+      options:
+        - label: I removed tokens, account identifiers, private paths, and other sensitive information from the pasted output.
+          required: true
+        - label: I kept the actual output and did not alter metrics to make the result look better.
+          required: true
+        - label: I understand that this research software and its backtests are not investment advice.
+          required: true

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Languages: [English](README.md) | [简体中文](README.zh-CN.md) | [繁體中�
 [**Run in Colab**](https://colab.research.google.com/github/initial-d/ml-quant-trading/blob/main/notebooks/quickstart_colab.ipynb)
 · [**See validated results**](docs/validation_dashboard.md)
 · [**Read the paper**](https://arxiv.org/abs/2507.07107)
-· [**Join the August reproduction challenge**](https://github.com/initial-d/ml-quant-trading/discussions/43)
+· [**Submit one reproduction report**](https://github.com/initial-d/ml-quant-trading/issues/new?template=reproduction_report.yml)
 
 > **August 2026 reproduction challenge:** run the zero-account Colab once and
-> post its generated report, environment, and commit SHA in
-> [Discussion #43](https://github.com/initial-d/ml-quant-trading/discussions/43).
+> submit its generated report, environment, and commit SHA with the
+> [structured report form](https://github.com/initial-d/ml-quant-trading/issues/new?template=reproduction_report.yml).
 > Successful and failed runs are both useful. Verifiable reports will be credited
-> in the Community Evidence section.
+> in the Community Evidence section and summarized in [Discussion #43](https://github.com/initial-d/ml-quant-trading/discussions/43).
 
 ---
 
@@ -53,7 +53,7 @@ demos, CI, tests, and benchmark tooling.
 | Run a larger validation | [Public-Data Validation](docs/public_data_validation.md) | Walk-forward baselines, costs, turnover, bootstrap CIs, and report artifacts |
 | Run A-share validation | [AkShare CSI 300 Report](docs/validation_akshare_csi300_20260729.md) | Zero-auth A-share validation on the current CSI 300 public universe |
 | Run paper-style public validation | [AkShare CSI 300 Daily 213-Factor Report](docs/validation_akshare_csi300_full_pipeline_20260729.md) | Daily 213-factor public-data approximation with turnover control |
-| Contribute one run | [August reproduction challenge](https://github.com/initial-d/ml-quant-trading/discussions/43) | Run Colab, post the generated report, and receive README credit |
+| Contribute one run | [Reproduction report form](https://github.com/initial-d/ml-quant-trading/issues/new?template=reproduction_report.yml) | Run Colab, submit the generated report, and receive README credit |
 
 ## Validation Dashboard
 
@@ -94,7 +94,7 @@ research pipeline.
 
 **Current calls for contributors**
 
-- Join the [August 2026 reproduction challenge](https://github.com/initial-d/ml-quant-trading/discussions/43): one Colab run, one generated report, success or failure.
+- Join the [August 2026 reproduction challenge](https://github.com/initial-d/ml-quant-trading/discussions/43): run Colab once, then use the [structured report form](https://github.com/initial-d/ml-quant-trading/issues/new?template=reproduction_report.yml), whether it succeeds or fails.
 - Try the [`v0.2.3` release](https://github.com/initial-d/ml-quant-trading/releases/tag/v0.2.3).
 - Read the [Research Card](docs/research_card.md) for intended use, current evidence, and non-goals.
 - Read the [public-data mini reproduction](docs/public_data_mini_reproduction.md).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,11 +18,11 @@ Languages: [English](README.md) | [简体中文](README.zh-CN.md) | [繁體中�
 [**Colab 在线运行**](https://colab.research.google.com/github/initial-d/ml-quant-trading/blob/main/notebooks/quickstart_colab.ipynb)
 · [**查看公开验证结果**](docs/validation_dashboard.md)
 · [**阅读论文**](https://arxiv.org/abs/2507.07107)
-· [**参加 8 月复现挑战**](https://github.com/initial-d/ml-quant-trading/discussions/43)
+· [**提交一次复现报告**](https://github.com/initial-d/ml-quant-trading/issues/new?template=reproduction_report.yml)
 
 > **2026 年 8 月复现挑战：**打开零账号 Colab 跑一次，把自动生成的报告、
-> 运行环境和 commit SHA 发布到 [Discussion #43](https://github.com/initial-d/ml-quant-trading/discussions/43)。
-> 成功和失败结果都欢迎；符合可验证性要求的报告会署名加入下方社区验证区。
+> 运行环境和 commit SHA 填入[结构化报告表单](https://github.com/initial-d/ml-quant-trading/issues/new?template=reproduction_report.yml)。
+> 成功和失败结果都欢迎；符合要求的报告会署名加入社区验证区，并汇总到 [Discussion #43](https://github.com/initial-d/ml-quant-trading/discussions/43)。
 
 ## 项目概述
 
@@ -36,7 +36,7 @@ Languages: [English](README.md) | [简体中文](README.zh-CN.md) | [繁體中�
 | 不安装直接体验 | [Google Colab](https://colab.research.google.com/github/initial-d/ml-quant-trading/blob/main/notebooks/quickstart_colab.ipynb) | 无需账号或行情 API 的浏览器内完整 Demo |
 | 查看真实公开数据结果 | [CSI 300 验证看板](docs/validation_dashboard.md) | 成本敏感性、换手率、基线与复现命令 |
 | 理解研究结论边界 | [Research Card](docs/research_card.md) | 适用范围、非目标、数据假设与已知限制 |
-| 贡献一次运行结果 | [8 月复现挑战](https://github.com/initial-d/ml-quant-trading/discussions/43) | 跑 Colab、提交自动报告并获得 README 署名 |
+| 贡献一次运行结果 | [复现报告表单](https://github.com/initial-d/ml-quant-trading/issues/new?template=reproduction_report.yml) | 跑 Colab、结构化提交报告并获得 README 署名 |
 
 ## 当前公开验证
 
@@ -56,7 +56,7 @@ Languages: [English](README.md) | [简体中文](README.zh-CN.md) | [繁體中�
 
 这些结果链接到原始 PR，便于检查环境、命令、限制和评审过程。你也可以
 [打开零账号 Colab，运行并提交生成的报告](https://colab.research.google.com/github/initial-d/ml-quant-trading/blob/main/notebooks/quickstart_colab.ipynb)。
-本月结果统一提交到 [2026 年 8 月复现挑战](https://github.com/initial-d/ml-quant-trading/discussions/43)。
+本月结果请用[结构化复现报告表单](https://github.com/initial-d/ml-quant-trading/issues/new?template=reproduction_report.yml)提交，并汇总到 [2026 年 8 月复现挑战](https://github.com/initial-d/ml-quant-trading/discussions/43)。
 
 ## 研究与教学用途声明
 


### PR DESCRIPTION
## What changed

- adds a dedicated GitHub Issue Form for successful, warning, and failed Colab or local demo runs
- requires commit, environment, generated output, and privacy/integrity confirmations
- updates the English and Simplified Chinese README calls to action to use the structured form
- keeps Discussion #43 as the challenge summary page

## Why

The August challenge is live but has no submissions yet. Asking users to compose an unstructured Discussion reply creates avoidable friction and inconsistent evidence. The form makes every report searchable, comparable, and safe to credit in the README.

## Validation

- parsed the Issue Form with Ruby/Psych YAML
- `git diff --check`

No runtime code is changed.