### PR TITLE
docs: remove first-run onboarding friction

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ deterministically from a fixed seed.
 ```bash
 git clone https://github.com/initial-d/ml-quant-trading.git
 cd ml-quant-trading
-pip install -e .[dev]        # add ,gpu for CUDA; add ,mosek for MOSEK solver
+python -m pip install -e '.[dev]'  # add ,gpu for CUDA; add ,mosek for MOSEK solver
 
 # One-command smoke test (synthetic data; no API key required)
 mlquant demo
@@ -239,7 +239,7 @@ For VS Code or GitHub Codespaces, use the included Dev Container:
 .devcontainer/devcontainer.json
 ```
 
-It installs Python 3.11 and the project with `pip install -e .[dev]`.
+It installs Python 3.11 and the project with `python -m pip install -e '.[dev]'`.
 
 <details>
 <summary><b>Maintainer, launch, and community resources</b></summary>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -95,7 +95,7 @@ Languages: [English](README.md) | [简体中文](README.zh-CN.md) | [繁體中�
 ```bash
 git clone https://github.com/initial-d/ml-quant-trading.git
 cd ml-quant-trading
-pip install -e .[dev]        # 如需 CUDA，请添加 ,gpu；如需 MOSEK solver，请添加 ,mosek
+python -m pip install -e '.[dev]'  # 如需 CUDA，请添加 ,gpu；如需 MOSEK solver，请添加 ,mosek
 
 # 一条命令跑通（Synthetic 数据，无需 API Key）
 mlquant demo

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -48,7 +48,7 @@ Languages: [English](README.md) | [简体中文](README.zh-CN.md) | [繁體中�
 ```bash
 git clone https://github.com/initial-d/ml-quant-trading.git
 cd ml-quant-trading
-pip install -e .[dev]        # 如需 CUDA，請加入 ,gpu；如需 MOSEK solver，請加入 ,mosek
+python -m pip install -e '.[dev]'  # 如需 CUDA，請加入 ,gpu；如需 MOSEK solver，請加入 ,mosek
 
 # 30 秒冒煙測試（Synthetic：200 檔股票 × 500 天）
 make paper CONFIG=configs/small.yaml

--- a/docs/benchmark_board.md
+++ b/docs/benchmark_board.md
@@ -12,7 +12,7 @@ community reports.
 ## How to Submit
 
 ```bash
-python -m pip install -e .[dev]
+python -m pip install -e '.[dev]'
 make benchmark
 ```
 

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -5,7 +5,7 @@ This page explains how to benchmark the tensor factor engine on synthetic data. 
 ## Quick Start
 
 ```bash
-python -m pip install -e .[dev]
+python -m pip install -e '.[dev]'
 python scripts/benchmark_tensor_factors.py --device auto
 ```
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -821,7 +821,7 @@
         </div>
         <pre><code>git clone https://github.com/initial-d/ml-quant-trading.git
 cd ml-quant-trading
-python -m pip install -e .[dev]
+python -m pip install -e '.[dev]'
 make paper CONFIG=configs/small.yaml</code></pre>
       </div>
     </section>

--- a/docs/launch_kit.md
+++ b/docs/launch_kit.md
@@ -114,7 +114,7 @@ Title: Building a reproducible ML factor research pipeline for A-shares
 ```bash
 git clone https://github.com/initial-d/ml-quant-trading.git
 cd ml-quant-trading
-python -m pip install -e .[dev]
+python -m pip install -e '.[dev]'
 mlquant demo
 ```
 

--- a/docs/reproducing_paper.md
+++ b/docs/reproducing_paper.md
@@ -21,7 +21,7 @@ Before comparing backtest numbers, read the [backtest assumptions and limitation
 ```bash
 git clone https://github.com/initial-d/ml-quant-trading.git
 cd ml-quant-trading
-python -m pip install -e .[dev]
+python -m pip install -e '.[dev]'
 
 # Tiny config: ~30 seconds end-to-end.
 make paper CONFIG=configs/small.yaml

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,8 +10,8 @@ easier to trust, and easier to extend.
 - Expand first-run onboarding based on new user feedback.
 - Add more examples for factor IC, attribution, and regime-specific diagnostics.
 - Add independent reproductions with explicit survivorship-bias and point-in-time data controls.
-- Evaluate a lightweight GitHub Project board for contributor tasks.
-- Evaluate automated pull-request review tooling after the first external PRs arrive.
+- Publish the package to PyPI so new users can install a tagged release without cloning.
+- Keep the contributor funnel focused on a small set of current, reviewable issues.
 
 ## Completed Launch Items
 
@@ -53,9 +53,9 @@ easier to trust, and easier to extend.
 
 ## Community Milestones
 
-- First external benchmark result.
-- First public-data reproduction issue.
-- First external PR.
-- First tagged release.
+- [x] First external benchmark result.
+- [x] First public-data reproduction issue.
+- [x] First external PR.
+- [x] First tagged release.
 - First Zenodo archive or DOI-backed software release.
 - First third-party tutorial or blog post.

--- a/docs/start_here.md
+++ b/docs/start_here.md
@@ -17,7 +17,7 @@ This page is the fastest path from discovering the repository to running somethi
 ```bash
 git clone https://github.com/initial-d/ml-quant-trading.git
 cd ml-quant-trading
-python -m pip install -e .[dev]
+python -m pip install -e '.[dev]'
 mlquant demo
 ```
 
@@ -98,7 +98,7 @@ Container:
 The container installs Python 3.11 and runs:
 
 ```bash
-python -m pip install -e .[dev]
+python -m pip install -e '.[dev]'
 ```
 
 This is the most reproducible path for first-time contributors who do not want to debug
@@ -117,7 +117,8 @@ The fastest useful contributions are:
 Good current entry points:
 
 - [Collect community CPU/GPU benchmark results](https://github.com/initial-d/ml-quant-trading/issues/7)
-- [Share benchmark and public-data reproductions](https://github.com/initial-d/ml-quant-trading/issues/12)
+- [Submit a structured Colab or local reproduction report](https://github.com/initial-d/ml-quant-trading/issues/new?template=reproduction_report.yml)
+- [Join the August 2026 reproduction challenge](https://github.com/initial-d/ml-quant-trading/discussions/43)
 - [Pair on a public-data validation or benchmark contribution](https://github.com/initial-d/ml-quant-trading/issues/22)
 
 ## 6. What Not to Expect


### PR DESCRIPTION
## Summary

- quote the editable-install extra so the documented command works in zsh as well as bash
- use `python -m pip` consistently in user-facing quick starts
- replace the closed Issue #12 link with the live structured reproduction form and August challenge
- refresh completed community milestones and add PyPI distribution to the near-term roadmap

## Why

The primary README install command used `.[dev]` without quoting it. On the default macOS zsh configuration, that can fail before pip runs with `zsh: no matches found: .[dev]`. The Start Here guide also sent prospective contributors to a closed issue.

These are small conversion leaks on the two highest-value paths: first successful run and first contribution.

## Validation

- `git diff --check`
- verified no remaining unquoted editable-install extras in active README/docs pages
- documentation-only change; no research or runtime logic changed