### PR TITLE
Name the cumulative cost field for what it is (cost_drag_cumulative)

### DIFF
--- a/docs/public_data_validation.md
+++ b/docs/public_data_validation.md
@@ -272,6 +272,46 @@ These intervals are diagnostics, not formal proof of statistical significance.
 They are most useful for spotting fragile point estimates and for comparing
 community reports that use the same universe and date range.
 
+## Metric Glossary
+
+Every column in the summary table, with its unit and time basis. The distinction
+that matters most is the last column: most figures are **per year**, one is a
+**total over the run**, and comparing across those two without noticing is easy.
+
+| column | unit | basis |
+|---|---|---|
+| `ann_return` | fraction | per year, geometric |
+| `gross_ann_return` | fraction | per year, geometric, before costs |
+| `ann_vol` | fraction | per year |
+| `sharpe`, `gross_sharpe` | ratio | per year |
+| `info_ratio` | ratio | per year, against the benchmark |
+| `alpha_ann` | fraction | per year, against the benchmark |
+| `max_dd` | fraction | worst peak-to-trough over the run |
+| `turnover` | fraction | average per rebalance |
+| `cost_drag_cumulative` | fraction | **total over the whole run**, arithmetic sum |
+| `final_equity` | multiple | total over the run, starting at 1.0 |
+| `effective_costs_bps` | bps per side | input, not a result |
+
+**`cost_drag_cumulative` is not annualised.** It is `sum(daily cost)` across
+every period in the backtest, so a strategy tested over eight years reports
+roughly twice the drag of the same strategy over four — at identical turnover
+and identical fees. Two consequences:
+
+- Do not read it as a rate beside `ann_return`. On a four-year run a
+  `cost_drag_cumulative` of 0.20 is about 5 percentage points a year, not 20.
+- Do not compare it between reports of different lengths. `turnover` and
+  `effective_costs_bps` are the length-independent figures; use those.
+
+It also will not reconcile exactly with `gross_ann_return − ann_return` even
+after dividing by the number of years, because the annualised returns compound
+while the cost sum is arithmetic. The gap is small on long runs and material on
+short ones. No derived "annualised cost drag" is published for that reason: an
+approximate number under an exact-sounding name is worse than an explicit one.
+
+`cost_drag` remains as a deprecated alias of `cost_drag_cumulative` for one
+release so archived reports and existing tooling keep working. New output should
+use the explicit name.
+
 ## Interpreting Results
 
 This benchmark is stronger than the tiny public-data IC note because it includes
@@ -279,8 +319,11 @@ a larger universe, walk-forward prediction, portfolio construction, turnover,
 drawdown, costs, uncertainty intervals, and baseline comparisons.
 
 When interpreting a factor strategy, always read net return together with
-`gross_ann_return`, `turnover`, and `cost_drag`. A strategy can have a positive
-gross return but still fail after costs if it trades too aggressively. That is
+`gross_ann_return` and `turnover` — all three are per-year figures, so they
+compare directly. `cost_drag_cumulative` is a total over the run rather than a
+rate (see the glossary above), so divide it by the number of years before
+holding it beside an annualised return. A strategy can have a positive gross
+return but still fail after costs if it trades too aggressively. That is
 especially important for naive factor blends such as `alpha101_mean`: a negative
 net result may be a turnover-control and portfolio-construction problem rather
 than evidence that the factor family has no research value.

--- a/docs/reproducing_paper.md
+++ b/docs/reproducing_paper.md
@@ -1,5 +1,8 @@
 # Reproducing the paper
 
+> **Units note.** `cost_drag` in the tables below is *cumulative over the run*, not annualised — unlike `ann_return`, `gross_ann_return` and `ann_vol` beside it. Divide by the number of years before comparing it with a per-year figure, and do not compare it across reports of different lengths. The field is named `cost_drag_cumulative` in new output; see [the metric glossary](public_data_validation.md#metric-glossary).
+
+
 The paper reports results on a proprietary Wind A-share panel that we
 cannot redistribute. We support two reproduction paths:
 

--- a/docs/validation_akshare_csi300_20260729.md
+++ b/docs/validation_akshare_csi300_20260729.md
@@ -1,5 +1,8 @@
 # AkShare Public A-Share Validation - CSI 300 - 2026-07-29
 
+> **Units note.** `cost_drag` in the tables below is *cumulative over the run*, not annualised — unlike `ann_return`, `gross_ann_return` and `ann_vol` beside it. Divide by the number of years before comparing it with a per-year figure, and do not compare it across reports of different lengths. The field is named `cost_drag_cumulative` in new output; see [the metric glossary](public_data_validation.md#metric-glossary).
+
+
 This report records the first full AkShare-backed public A-share validation run
 for `v0.2.2`. It is a reproducibility and engineering diagnostic, not a trading
 claim and not a full paper reproduction.

--- a/docs/validation_akshare_csi300_full_pipeline_20260729.md
+++ b/docs/validation_akshare_csi300_full_pipeline_20260729.md
@@ -1,5 +1,8 @@
 # AkShare CSI 300 Daily 213-Factor Validation - 2026-07-29
 
+> **Units note.** `cost_drag` in the tables below is *cumulative over the run*, not annualised — unlike `ann_return`, `gross_ann_return` and `ann_vol` beside it. Divide by the number of years before comparing it with a per-year figure, and do not compare it across reports of different lengths. The field is named `cost_drag_cumulative` in new output; see [the metric glossary](public_data_validation.md#metric-glossary).
+
+
 This report records a paper-style public-data approximation on the AkShare CSI
 300 universe. Unlike the lighter `v0.2.2` baseline report, this run uses the
 full 213-factor library and daily portfolio evaluation.

--- a/docs/validation_baostock_20260716.md
+++ b/docs/validation_baostock_20260716.md
@@ -1,5 +1,8 @@
 # Baostock A-Share Public-Data Validation Report
 
+> **Units note.** `cost_drag` in the tables below is *cumulative over the run*, not annualised — unlike `ann_return`, `gross_ann_return` and `ann_vol` beside it. Divide by the number of years before comparing it with a per-year figure, and do not compare it across reports of different lengths. The field is named `cost_drag_cumulative` in new output; see [the metric glossary](public_data_validation.md#metric-glossary).
+
+
 > 2026-07-16 · Windows 11 · PyTorch 2.13.0+cpu · Python 3.12.7
 
 ## Command

--- a/scripts/aggregate_validation_reports.py
+++ b/scripts/aggregate_validation_reports.py
@@ -27,7 +27,7 @@ LEADERBOARD_COLUMNS = (
     "sharpe_ci_high",
     "max_dd",
     "turnover",
-    "cost_drag",
+    "cost_drag_cumulative",
     "effective_costs_bps",
     "final_equity",
     "tradable_ratio",
@@ -92,7 +92,10 @@ def _flatten_report(path: Path) -> list[dict[str, Any]]:
             "sharpe_ci_high": result.get("sharpe_ci_high"),
             "max_dd": result.get("max_dd"),
             "turnover": result.get("turnover"),
-            "cost_drag": result.get("cost_drag"),
+            # Accept the legacy key so archived reports still aggregate.
+            "cost_drag_cumulative": result.get(
+                "cost_drag_cumulative", result.get("cost_drag")
+            ),
             "effective_costs_bps": result.get("effective_costs_bps", metadata.get("effective_costs_bps")),
             "final_equity": result.get("final_equity"),
             "tradable_ratio": panel.get("tradable_ratio"),

--- a/scripts/audit_validation_report.py
+++ b/scripts/audit_validation_report.py
@@ -106,8 +106,13 @@ def audit_report(
             findings.append(_finding("error", f"results[{index}]", "result row is not an object"))
             continue
         strategy = row.get("strategy") or f"results[{index}]"
-        for field in ("ann_return", "ann_vol", "sharpe", "max_dd", "turnover", "cost_drag", "final_equity"):
-            value = _as_float(row.get(field))
+        for field in ("ann_return", "ann_vol", "sharpe", "max_dd", "turnover", "cost_drag_cumulative", "final_equity"):
+            # `cost_drag` is the pre-rename name; archived reports carry it.
+            value = _as_float(
+                row.get(field)
+                if field != "cost_drag_cumulative"
+                else row.get(field, row.get("cost_drag"))
+            )
             if value is None:
                 findings.append(_finding("warning", f"{strategy}.{field}", f"missing or non-finite {field}"))
         max_dd = _as_float(row.get("max_dd"))

--- a/scripts/public_data_validation.py
+++ b/scripts/public_data_validation.py
@@ -704,7 +704,7 @@ def _markdown_table(rows: Sequence[dict[str, float | int | str]]) -> str:
         "sharpe",
         "max_dd",
         "turnover",
-        "cost_drag",
+        "cost_drag_cumulative",
         "gross_ann_return",
         "gross_sharpe",
         "info_ratio",
@@ -731,7 +731,7 @@ def _cost_sensitivity_table(rows: Sequence[dict[str, float | int | str]]) -> str
         "sharpe",
         "max_dd",
         "turnover",
-        "cost_drag",
+        "cost_drag_cumulative",
         "final_equity",
     ]
     if any("sharpe_ci_low" in row for row in rows):

--- a/src/mlquant/backtest/engine.py
+++ b/src/mlquant/backtest/engine.py
@@ -33,8 +33,19 @@ class BacktestResult:
     gross_returns:     np.ndarray          # [T] gross
     cumulative_equity: np.ndarray          # [T]
     weights:           np.ndarray          # [T, N]
-    cost_drag:         float               # total cost paid (cumulative)
+    cost_drag_cumulative: float            # total cost paid over the whole run
     metrics:           dict                # summary table
+
+    @property
+    def cost_drag(self) -> float:
+        """Deprecated alias for :attr:`cost_drag_cumulative`.
+
+        The name was ambiguous: this figure is cumulative over the backtest,
+        while ``ann_return``, ``gross_ann_return`` and ``ann_vol`` alongside it
+        are annualised. Kept for one release so existing scripts and archived
+        JSON reports keep working. Prefer ``cost_drag_cumulative``.
+        """
+        return self.cost_drag_cumulative
 
     def summary(self) -> dict:
         return self.metrics
@@ -84,6 +95,10 @@ def run_backtest(
         "calmar":     metrics.calmar_ratio(net),
         "max_dd":     metrics.max_drawdown(net),
         "turnover":   metrics.turnover(weights),
+        # Cumulative over the run, unlike its annualised neighbours above.
+        # Both keys carry the same value for one release; `cost_drag` is
+        # deprecated. See docs/public_data_validation.md for the glossary.
+        "cost_drag_cumulative": float(cost.sum()),
         "cost_drag":  float(cost.sum()),
         "n_periods":  int(T),
     }
@@ -98,6 +113,6 @@ def run_backtest(
         gross_returns=gross,
         cumulative_equity=equity,
         weights=weights,
-        cost_drag=float(cost.sum()),
+        cost_drag_cumulative=float(cost.sum()),
         metrics=summary,
     )

--- a/tests/test_cost_drag_units.py
+++ b/tests/test_cost_drag_units.py
@@ -1,0 +1,59 @@
+"""`cost_drag_cumulative` means what its name says.
+
+The field was called `cost_drag` and sat in a summary row beside `ann_return`,
+`gross_ann_return` and `ann_vol`, which are annualised. It is not: it is the
+cost paid over the whole backtest. Nothing in the output said so, and
+`docs/public_data_validation.md` asks the reader to compare it with those
+neighbours.
+
+These tests pin the distinction so the name and the quantity cannot drift apart
+again.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from mlquant.backtest.engine import run_backtest
+
+
+def _alternating_book(periods: int, n: int = 2) -> tuple[np.ndarray, np.ndarray]:
+    """A book that fully rebalances every period, so cost accrues steadily."""
+    weights = np.zeros((periods, n))
+    weights[0::2, 0] = 1.0
+    weights[1::2, 1] = 1.0
+    returns = np.zeros((periods, n))
+    return weights, returns
+
+
+def test_cost_drag_is_cumulative_not_per_period():
+    """Doubling the backtest doubles the cost, because the field is a total.
+
+    This is the check that distinguishes a cumulative quantity from an
+    annualised one: an annualised figure would be unchanged.
+    """
+    short = run_backtest(*_alternating_book(200), costs_bps=5.0)
+    long = run_backtest(*_alternating_book(400), costs_bps=5.0)
+
+    assert short.cost_drag_cumulative > 0
+    ratio = long.cost_drag_cumulative / short.cost_drag_cumulative
+    assert 1.95 < ratio < 2.05, f"expected ~2x over twice the periods, got {ratio:.3f}"
+
+    # Turnover is a rate and must not move with the length of the run.
+    assert np.isclose(
+        short.metrics["turnover"], long.metrics["turnover"], rtol=0.05
+    ), "turnover moved with run length; the fixture is not comparable"
+
+
+def test_cost_drag_scales_with_the_fee():
+    cheap = run_backtest(*_alternating_book(200), costs_bps=1.0)
+    dear = run_backtest(*_alternating_book(200), costs_bps=10.0)
+    assert np.isclose(dear.cost_drag_cumulative, 10 * cheap.cost_drag_cumulative)
+
+
+def test_legacy_alias_still_reads():
+    """Archived reports and older scripts use `cost_drag`; both must work."""
+    res = run_backtest(*_alternating_book(120), costs_bps=5.0)
+
+    assert res.cost_drag == res.cost_drag_cumulative
+    assert res.metrics["cost_drag"] == res.metrics["cost_drag_cumulative"]
+    assert "cost_drag_cumulative" in res.metrics


### PR DESCRIPTION
Closes the unit ambiguity discussed in #22.

`run_backtest` stores `float(cost.sum())` — the cost paid over the whole backtest — while `ann_return`, `gross_ann_return` and `ann_vol` beside it in the same summary row are annualised. Nothing in the output, the docs or the published reports said the units differ, and `docs/public_data_validation.md` explicitly asks the reader to compare them.

## Evidence

A cumulative quantity scales with the length of the run; an annualised one does not. Same config, same seed, only `--synthetic-dates` changed:

| days | ann_return | turnover | cost_drag | per year |
|---:|---:|---:|---:|---:|
| 600 | −0.3274 | 0.1899 | 0.1592 | 0.0669 |
| 1200 | −0.1844 | 0.1854 | 0.3112 | 0.0654 |
| 2400 | −0.1158 | 0.1891 | 0.6351 | 0.0667 |

Turnover flat, per-year drag flat, `cost_drag` doubling with the run.

## Changes, against the acceptance points in #22

1. **`cost_drag_cumulative`** is the explicit summary and report field.
2. **`cost_drag` kept as an alias** in the metrics dict for one release, so archived JSON reports and existing tooling keep working.
3. **`BacktestResult.cost_drag`** is now a property returning `cost_drag_cumulative`, with a deprecation note in its docstring and **no runtime warning** — research runs stay quiet.
4. **Summary, cost-sensitivity, aggregation and audit paths** emit the explicit name and still read the legacy one. `aggregate_validation_reports.py` falls back to `cost_drag`; `audit_validation_report.py` accepts either, so an archived report raises no findings.
5. **Metric glossary** added to `docs/public_data_validation.md` with unit and time basis for every column, and the interpretation paragraph now compares like with like. The four published reports carrying the field get a short units note rather than being regenerated.
6. **Regression tests** in `tests/test_cost_drag_units.py`: duration scaling (2× periods → ~2× drag while turnover is unchanged), fee scaling, and the legacy alias.
7. **No derived "annualised cost drag."** Dividing the arithmetic cost sum by years does not reconcile with the compounded annualised returns — measured deviations of 30%, 16% and 8.5% on the three runs above — so an approximate figure under an exact-sounding name would be worse than an explicit cumulative one. The glossary says this rather than hiding it.

## Verification

```bash
python scripts/public_data_validation.py --source synthetic --synthetic-dates 600 \
  --models momentum_20 --epochs 1 --seed 7 --output-dir artifacts/len_600
```

- New reports carry `cost_drag_cumulative` as the column; `cost_drag` no longer appears as a table header.
- `summary.json` carries both keys with equal values.
- An archived report with `cost_drag_cumulative` stripped still audits clean.
- `92 passed` (89 existing + 3 new).

Environment: macOS 26.5 arm64, Python 3.10.16, torch 2.9.1, CPU, branched from `fd68eeb`.

Historical validation artifacts are not regenerated, per your note that it is not required in the same PR.
