### PR TITLE
Launch v0.2.4 metric clarity story

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,28 @@
 
 ## Unreleased
 
-### Dashboard
+## 0.2.4 - Metric Clarity and Contributor-Led Review
+
+This patch release turns an external review finding into a clearer reporting
+contract. The backtest engine's cost total was mathematically correct, but its
+old name made it easy to compare a cumulative value with annualized neighbors.
+The release makes the time basis explicit without inventing a misleading
+derived metric.
+
+### Metric clarity
+
+- Renamed the primary output from `cost_drag` to `cost_drag_cumulative`.
+- Kept `cost_drag` as a compatibility alias in metrics and `BacktestResult` for
+  existing scripts and archived reports.
+- Updated summary tables, cost-sensitivity output, report aggregation, and
+  report auditing to write the explicit name and read the legacy one.
+- Added a metric glossary with unit and time basis for every validation column.
+- Added regression tests for duration scaling, fee scaling, and the legacy alias.
+- Added a technical case study crediting
+  [@sergio12S](https://github.com/sergio12S) and
+  [PR #47](https://github.com/initial-d/ml-quant-trading/pull/47).
+
+### Dashboard and onboarding
 
 - Added a cost-sensitivity line chart to the README and validation dashboard.
 - The full AkShare CSI 300 pipeline now exports `equity_curves.csv` for future
@@ -11,6 +32,11 @@
   ticker as unavailable.
 - The full AkShare CSI 300 pipeline now refuses to publish validation outputs
   when the panel tradable ratio falls below `--min-tradable-ratio`.
+- Removed the manual Colab report-copy step so first-time contributors can use
+  the generated artifact directly.
+- Tightened the README first screen around the runnable path, cost-aware
+  evidence, and community contributions.
+- Synchronized the package metadata and `mlquant.__version__` at `0.2.4`.
 
 ## 0.2.3 - Daily 213-Factor Validation Dashboard
 

--- a/README.md
+++ b/README.md
@@ -1,53 +1,62 @@
 # ml-quant-trading
 
-> **Machine Learning Enhanced Multi-Factor Quantitative Trading**
-> — A Cross-Sectional Portfolio Optimization Approach with Bias Correction
->
-> [arXiv:2507.07107](https://arxiv.org/abs/2507.07107) &nbsp;|&nbsp;
-> [Hugging Face Papers](https://huggingface.co/papers/2507.07107) &nbsp;|&nbsp; Yimin Du, 2025
+**From 213 mask-aware PyTorch factors to cost-aware portfolios and backtests —
+one reproducible research stack.**
+
+Run the whole path on synthetic or public market data: panel construction,
+factor computation, bias correction, ML baselines, portfolio optimization,
+vectorized backtesting, and auditable reports.
 
 [![CI](https://github.com/initial-d/ml-quant-trading/actions/workflows/ci.yml/badge.svg)](https://github.com/initial-d/ml-quant-trading/actions/workflows/ci.yml)
 [![GitHub stars](https://img.shields.io/github/stars/initial-d/ml-quant-trading?style=flat&logo=github&label=Stars)](https://github.com/initial-d/ml-quant-trading/stargazers)
-[![GitHub forks](https://img.shields.io/github/forks/initial-d/ml-quant-trading?style=flat&logo=github&label=Forks)](https://github.com/initial-d/ml-quant-trading/forks)
 [![Release](https://img.shields.io/github/v/release/initial-d/ml-quant-trading?display_name=tag)](https://github.com/initial-d/ml-quant-trading/releases)
-[![Project site](https://img.shields.io/badge/project-site-0f7b63.svg)](https://initial-d.github.io/ml-quant-trading/)
 [![arXiv](https://img.shields.io/badge/arXiv-2507.07107-b31b1b.svg)](https://arxiv.org/abs/2507.07107)
-[![Hugging Face Papers](https://img.shields.io/badge/Hugging%20Face-Papers-ffcc4d.svg)](https://huggingface.co/papers/2507.07107)
-[![Awesome Quant](https://img.shields.io/badge/Awesome%20Quant-Factor%20Analysis-4c78a8.svg)](https://github.com/wilsonfreitas/awesome-quant#factor-analysis)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9%2B-blue.svg)](https://www.python.org/downloads/)
 [![MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
-[![ruff](https://img.shields.io/badge/style-ruff-000000.svg)](https://docs.astral.sh/ruff/)
 
 Languages: [English](README.md) | [简体中文](README.zh-CN.md) | [繁體中文](README.zh-TW.md)
 
-![ml-quant-trading social preview](docs/assets/readme-preview.png)
-
 [**Run in Colab**](https://colab.research.google.com/github/initial-d/ml-quant-trading/blob/main/notebooks/quickstart_colab.ipynb)
-· [**See validated results**](docs/validation_dashboard.md)
+· [**Run the 30–90 second demo**](#quick-start)
+· [**See cost-aware results**](docs/validation_dashboard.md)
 · [**Read the paper**](https://arxiv.org/abs/2507.07107)
-· [**Submit one reproduction report**](https://github.com/initial-d/ml-quant-trading/issues/new?template=reproduction_report.yml)
 
-> **August 2026 reproduction challenge:** run the zero-account Colab once and
-> submit its generated report, environment, and commit SHA with the
-> [structured report form](https://github.com/initial-d/ml-quant-trading/issues/new?template=reproduction_report.yml).
-> Successful and failed runs are both useful. Verifiable reports will be credited
-> in the Community Evidence section and summarized in [Discussion #43](https://github.com/initial-d/ml-quant-trading/discussions/43).
+> **New in v0.2.4 — a community review changed how we report trading costs.**
+> External contributor [@sergio12S](https://github.com/sergio12S) showed that
+> `cost_drag` was cumulative over a run while neighboring metrics were annualized.
+> The math was correct; the label made a wrong comparison too easy. Read the
+> [technical story](docs/backtest_cost_drag_story.md) or inspect
+> [PR #47](https://github.com/initial-d/ml-quant-trading/pull/47).
 
 ---
 
-## What is this?
+## Why this repository?
 
-A **clean, fork-friendly, end-to-end** A-share quantitative trading system:
+| You get | Why it matters |
+|---|---|
+| **213 factor dimensions** | Mask-aware PyTorch factors with documented families and tensor primitives |
+| **One end-to-end path** | Data → factors → models → portfolio → cost-aware backtest → report |
+| **Public and synthetic data** | Start without proprietary data or an API key, then move to AkShare, Baostock, or yfinance |
+| **Evidence, including failures** | Costs, turnover, baselines, caveats, and negative results stay visible |
+| **A contribution path** | CI, tests, report templates, Colab, and newcomer-sized research tasks |
 
-**In one clone, you get:** a tensor factor engine, 213 factor dimensions, bias correction,
-ML baselines, Markowitz portfolio optimization, vectorized backtesting, synthetic/public-data
-demos, CI, tests, and benchmark tooling.
+## Quick Start
+
+```bash
+git clone https://github.com/initial-d/ml-quant-trading.git
+cd ml-quant-trading
+python -m pip install -e '.[dev]'
+mlquant demo
+```
+
+No market-data account is required. The deterministic demo prints each pipeline
+stage and writes a shareable Markdown/JSON report.
 
 ## Fast Path
 
 | If you want to... | Start here | What you get |
 |---|---|---|
-| See the project run | `mlquant demo` | A 30-90 second synthetic end-to-end smoke test |
+| See the project run | [`mlquant demo`](#quick-start) | A 30–90 second synthetic end-to-end smoke test |
 | Understand the claims | [Research Card](docs/research_card.md) | Intended use, non-goals, validation status, and data caveats |
 | Try public data | [Public-Data Mini Reproduction](docs/public_data_mini_reproduction.md) | A small yfinance factor-IC check with documented outputs |
 | Run a larger validation | [Public-Data Validation](docs/public_data_validation.md) | Walk-forward baselines, costs, turnover, bootstrap CIs, and report artifacts |
@@ -83,6 +92,7 @@ in [PR #42](https://github.com/initial-d/ml-quant-trading/pull/42).
 | [PR #35](https://github.com/initial-d/ml-quant-trading/pull/35) | Neutralization and Baostock robustness fixes |
 | [PR #36](https://github.com/initial-d/ml-quant-trading/pull/36) | English handbook for all factor families |
 | [PR #42](https://github.com/initial-d/ml-quant-trading/pull/42) | Zero-account AkShare loader enabling CSI 300 validation |
+| [PR #47](https://github.com/initial-d/ml-quant-trading/pull/47) | Clarified cumulative cost-drag units across code, reports, tests, and documentation |
 
 Independent results are linked to their pull requests so the environment,
 commands, limitations, and review history remain inspectable. Want to add
@@ -92,10 +102,16 @@ This repository is validation-first: simple baselines, transaction costs,
 public-data failure modes, and negative results are documented alongside the
 research pipeline.
 
-**Current calls for contributors**
+**One useful contribution takes about ten minutes:** run the
+[zero-account Colab](https://colab.research.google.com/github/initial-d/ml-quant-trading/blob/main/notebooks/quickstart_colab.ipynb),
+then submit the generated report through the
+[structured form](https://github.com/initial-d/ml-quant-trading/issues/new?template=reproduction_report.yml).
+Successful and failed runs are both useful and credited.
+
+**Other current calls for contributors**
 
 - Join the [August 2026 reproduction challenge](https://github.com/initial-d/ml-quant-trading/discussions/43): run Colab once, then use the [structured report form](https://github.com/initial-d/ml-quant-trading/issues/new?template=reproduction_report.yml), whether it succeeds or fails.
-- Try the [`v0.2.3` release](https://github.com/initial-d/ml-quant-trading/releases/tag/v0.2.3).
+- Try the [`v0.2.4` release](https://github.com/initial-d/ml-quant-trading/releases/tag/v0.2.4).
 - Read the [Research Card](docs/research_card.md) for intended use, current evidence, and non-goals.
 - Read the [public-data mini reproduction](docs/public_data_mini_reproduction.md).
 - Share benchmark or public-data results in [Discussions #13](https://github.com/initial-d/ml-quant-trading/discussions/13).
@@ -131,19 +147,6 @@ research pipeline.
 | `portfolio.markowitz` | Cross-sectional Markowitz (shrunk cov, no-short) |
 | `backtest.engine` | Vectorised backtest → Sharpe / IC / IR / DD |
 
----
-
-## Why Star or Fork This Repository?
-
-- You want a runnable reference implementation for ML-enhanced multi-factor research.
-- You need a factor pipeline that handles masks, limit-up / limit-down events, halts, and cross-sectional operations.
-- You want to reproduce or extend the accompanying paper without rebuilding data, factor, model, portfolio, and backtest modules from scratch.
-- You are looking for a practical template for testing quantitative finance research code.
-
-If you build on this work, please consider citing the paper and opening issues or pull requests for reproducibility notes, new examples, or benchmark results.
-
----
-
 ## Data Sources
 
 | Source | Market | Access | Notes |
@@ -158,7 +161,7 @@ yfinance data are downloaded on-demand by the loader scripts. Public upstream
 interfaces can change or rate-limit requests. Synthetic data is generated
 deterministically from a fixed seed.
 
-## Quick Start
+## Installation and Demos
 
 ```bash
 git clone https://github.com/initial-d/ml-quant-trading.git

--- a/docs/backtest_cost_drag_story.md
+++ b/docs/backtest_cost_drag_story.md
@@ -1,0 +1,104 @@
+# The Backtest Metric Was Correct — and Still Easy to Misread
+
+An external contributor found a reporting problem in `ml-quant-trading` that is
+worth checking in any backtest framework.
+
+The engine reported `cost_drag` beside `ann_return`, `gross_ann_return`, and
+`ann_vol`. Those neighboring metrics are annualized. `cost_drag` was not: it was
+the arithmetic sum of trading costs over the entire run.
+
+The calculation was correct. The interface made an incorrect comparison look
+reasonable.
+
+## The unit test that exposed the problem
+
+[@sergio12S](https://github.com/sergio12S) ran the same synthetic configuration
+at three different backtest lengths. Turnover and cost per year stayed roughly
+constant, while the reported total grew with the number of periods:
+
+| periods | annual return | turnover | old `cost_drag` | approximate cost per year |
+|---:|---:|---:|---:|---:|
+| 600 | -0.3274 | 0.1899 | 0.1592 | 0.0669 |
+| 1,200 | -0.1844 | 0.1854 | 0.3112 | 0.0654 |
+| 2,400 | -0.1158 | 0.1891 | 0.6351 | 0.0667 |
+
+Doubling the run roughly doubled `cost_drag`. That is exactly what a cumulative
+quantity should do — and exactly what an annualized quantity should not do.
+
+The finding and implementation are reviewable in
+[PR #47](https://github.com/initial-d/ml-quant-trading/pull/47).
+
+## Why subtraction does not fix it
+
+It is tempting to calculate an annual cost number as:
+
+```text
+gross_ann_return - ann_return
+```
+
+or to divide cumulative cost by the number of years. Neither produces an exact
+identity:
+
+- cumulative cost is an arithmetic sum of per-period costs;
+- annual returns are geometric, compounded quantities;
+- costs alter the equity path on which later returns compound.
+
+An approximate annualized cost figure can be useful for diagnostics, but it
+should not be published under an exact-sounding name without a defined formula.
+This project therefore chose the narrower fix: name the quantity for what it is.
+
+## The reporting contract now
+
+New output uses:
+
+```python
+result.metrics["cost_drag_cumulative"]
+result.cost_drag_cumulative
+```
+
+The old name remains available as a compatibility alias:
+
+```python
+result.metrics["cost_drag"]
+result.cost_drag
+```
+
+Report aggregation and auditing also accept archived JSON files that contain
+only `cost_drag`. New Markdown and cost-sensitivity tables emit the explicit
+name.
+
+Regression tests pin three behaviors:
+
+1. twice as many periods produce roughly twice the cumulative cost;
+2. ten times the fee produces ten times the cumulative cost;
+3. the legacy alias returns the same value.
+
+The complete unit and time-basis glossary lives in
+[Public-Data Validation](public_data_validation.md#metric-glossary).
+
+## Audit your own backtest
+
+For every metric in a result table, write down two things:
+
+| Question | Typical answers |
+|---|---|
+| What is the unit? | fraction, currency, basis points, ratio, multiple |
+| What is the time basis? | per period, per year, average rebalance, cumulative run |
+
+Then look for rows that mix cumulative and annualized values. Pay special
+attention to costs, turnover, drawdown, alpha, and final equity. A correct
+calculation with an ambiguous label can survive tests and still lead readers to
+the wrong conclusion.
+
+## Why this contribution matters
+
+Open-source research becomes more credible when outsiders can challenge the
+reporting contract, not only the implementation. This change was proposed by a
+community contributor, reviewed against archived-report compatibility, tested
+locally, and passed CI on Python 3.9, 3.10, and 3.11.
+
+That review trail is more useful than a perfect-looking backtest screenshot.
+
+Try the project in the
+[zero-account Colab](https://colab.research.google.com/github/initial-d/ml-quant-trading/blob/main/notebooks/quickstart_colab.ipynb),
+or [report another ambiguous metric](https://github.com/initial-d/ml-quant-trading/issues/new?template=research_question.yml).

--- a/docs/launch_kit_v0.2.4.md
+++ b/docs/launch_kit_v0.2.4.md
@@ -1,0 +1,134 @@
+# v0.2.4 Launch Kit — Metric Clarity
+
+Use one channel at a time. Reply to technical questions before opening another
+thread. Zhihu and JoinQuant are intentionally excluded because the project has
+already been posted there.
+
+Canonical links:
+
+- Repository: <https://github.com/initial-d/ml-quant-trading>
+- Technical story: <https://github.com/initial-d/ml-quant-trading/blob/main/docs/backtest_cost_drag_story.md>
+- Pull request: <https://github.com/initial-d/ml-quant-trading/pull/47>
+- Release: <https://github.com/initial-d/ml-quant-trading/releases/tag/v0.2.4>
+- Colab: <https://colab.research.google.com/github/initial-d/ml-quant-trading/blob/main/notebooks/quickstart_colab.ipynb>
+
+## Hacker News
+
+### Title
+
+Show HN: A contributor found our backtest cost metric was easy to misread
+
+### Text
+
+An external contributor noticed that our `cost_drag` value was cumulative over
+the entire backtest, while the metrics beside it (`ann_return`,
+`gross_ann_return`, `ann_vol`) were annualized.
+
+The calculation was correct, but the label made a wrong comparison look
+reasonable. Doubling the backtest length roughly doubled the reported cost drag
+while turnover and cost per year stayed flat.
+
+We renamed the primary field to `cost_drag_cumulative`, kept a compatibility
+alias for archived reports, added unit/time-basis documentation, and pinned the
+behavior with regression tests. I wrote up the evidence and why simply
+subtracting annualized returns does not produce an exact cost identity.
+
+I would value criticism of the reporting contract and examples of similar unit
+ambiguities in other backtest engines.
+
+Story: https://github.com/initial-d/ml-quant-trading/blob/main/docs/backtest_cost_drag_story.md
+
+## Reddit — r/algotrading or r/quant
+
+### Title
+
+Our cost metric was mathematically correct but semantically misleading
+
+### Text
+
+An external contributor caught a subtle reporting issue in my open-source
+backtest stack. `cost_drag` was the arithmetic sum of costs over the full run,
+but it appeared beside annualized return and volatility metrics.
+
+Same configuration, different durations: 600 periods produced 0.1592 cost
+drag, 1,200 produced 0.3112, and 2,400 produced 0.6351. Cost per year and
+turnover stayed roughly flat. The implementation was doing what it said in the
+code, but the table did not communicate the time basis.
+
+The fix is intentionally boring: call it `cost_drag_cumulative`, preserve the
+old key for compatibility, document every metric's unit/time basis, and add
+duration-scaling tests. We did not invent an exact-looking “annualized cost
+drag,” because arithmetic cost sums do not reconcile exactly with compounded
+annual returns.
+
+What other backtest metrics have you seen misread because their time basis was
+implicit?
+
+Technical write-up and code: https://github.com/initial-d/ml-quant-trading/blob/main/docs/backtest_cost_drag_story.md
+
+## V2EX
+
+### 标题
+
+[分享创造] 一个计算正确、却很容易被读错的回测成本指标
+
+### 正文
+
+项目最近收到一个外部贡献者 PR。他发现回测表里的 `cost_drag` 是整个区间的累计
+成本，但它旁边的 `ann_return`、`gross_ann_return` 和 `ann_vol` 都是年化指标。
+
+同一配置只改变回测长度，600、1200、2400 个周期的成本分别约为 0.1592、
+0.3112、0.6351；换手和每年成本基本不变。计算没有错，但命名会诱导读者把累计量
+和年化量直接比较。
+
+现在主字段改成了 `cost_drag_cumulative`，旧字段保留兼容；同时给每个指标补了
+单位和时间口径，并增加长度缩放测试。没有硬造一个“年化成本拖累”，因为算术成本
+和复合年化收益并不能精确对账。
+
+想请大家帮忙挑刺：你还见过哪些“代码算对了、接口却容易让人读错”的指标？
+
+技术记录与代码：
+https://github.com/initial-d/ml-quant-trading/blob/main/docs/backtest_cost_drag_story.md
+
+## 掘金
+
+### 标题
+
+回测指标的隐藏陷阱：累计交易成本为什么不能直接对比年化收益
+
+### 导语
+
+一次外部代码审查暴露了一个典型工程问题：公式和实现都正确，并不代表报告不会
+误导。本文用长度缩放实验解释累计成本、年化收益和复合路径之间的差异，并展示
+如何在不破坏旧报告的前提下修复字段契约。
+
+正文直接改编
+[`backtest_cost_drag_story.md`](backtest_cost_drag_story.md)，保留实验表格、迁移
+代码和“审计自己的回测”章节。结尾只放技术故事和仓库链接，不使用收益截图。
+
+## X / LinkedIn
+
+An external contributor found a subtle issue in my backtest project:
+
+`cost_drag` was cumulative over the full run. The metrics beside it were
+annualized.
+
+The math was correct. The interface made a wrong comparison look reasonable.
+
+We renamed the field, kept backward compatibility, documented every metric's
+unit/time basis, and added duration-scaling tests.
+
+Open-source review working as intended:
+https://github.com/initial-d/ml-quant-trading/blob/main/docs/backtest_cost_drag_story.md
+
+## Posting Order
+
+1. Publish the GitHub release and Discussion first so every external link has a
+   stable landing page.
+2. Hacker News or Reddit next — choose one, not both on the same day.
+3. Reply for 24 hours and incorporate legitimate corrections.
+4. Publish V2EX or Juejin 48 hours later with a rewritten opening.
+5. Use X or LinkedIn as a short pointer, not a duplicate long post.
+
+Before posting, re-check each community's current self-promotion rules. Ask for
+technical criticism or reproduction evidence, never votes or stars.

--- a/docs/release_draft_v0.2.4.md
+++ b/docs/release_draft_v0.2.4.md
@@ -1,0 +1,56 @@
+# v0.2.4 - Metric Clarity and Contributor-Led Review
+
+`v0.2.4` makes the time basis of backtest trading costs explicit. An external
+contributor showed that the old `cost_drag` label sat beside annualized metrics
+even though it represented a cumulative total over the whole run.
+
+The calculation was correct; the reporting contract was too easy to misread.
+
+## Highlights
+
+- New output uses `cost_drag_cumulative` in result tables and reports.
+- The legacy `cost_drag` key and property remain available as compatibility
+  aliases.
+- Aggregation and audit tools continue to accept archived reports.
+- A metric glossary now records the unit and time basis of every validation
+  column.
+- Regression tests cover duration scaling, fee scaling, and legacy access.
+- The README now leads with the runnable path and community-reviewed evidence.
+- Package metadata and `mlquant.__version__` are synchronized at `0.2.4`.
+
+## Community Credit
+
+Thank you to [@sergio12S](https://github.com/sergio12S) for identifying the
+ambiguity, supplying controlled evidence, designing the compatibility path,
+and adding the implementation, documentation, and tests in
+[PR #47](https://github.com/initial-d/ml-quant-trading/pull/47).
+
+Read the full technical story:
+[The Backtest Metric Was Correct — and Still Easy to Misread](https://github.com/initial-d/ml-quant-trading/blob/main/docs/backtest_cost_drag_story.md).
+
+## Migration
+
+Prefer the explicit field in new code:
+
+```python
+result.cost_drag_cumulative
+result.metrics["cost_drag_cumulative"]
+```
+
+Existing reads continue to work:
+
+```python
+result.cost_drag
+result.metrics["cost_drag"]
+```
+
+## Verification
+
+- Full local test suite: 92 passed.
+- Ruff: passed.
+- GitHub CI: Python 3.9, 3.10, and 3.11 passed, including the CLI smoke test.
+
+## Research Boundary
+
+This release improves reporting clarity. It does not add a new trading signal,
+change historical validation results, or claim live-trading profitability.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlquant"
-version = "0.2.3"
+version = "0.2.4"
 description = "Reference implementation of ‘ML-Enhanced Multi-Factor Quantitative Trading’ (arXiv:2507.07107)."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/mlquant/__init__.py
+++ b/src/mlquant/__init__.py
@@ -14,5 +14,5 @@ import torch or cvxpy. Sub-packages are loaded lazily on demand.
 """
 from __future__ import annotations
 
-__version__ = "0.1.0"
+__version__ = "0.2.4"
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary

- turn the contributor-led cost-drag clarification into a concise technical story
- tighten the README first screen around the runnable path, evidence, and community review
- add channel-specific launch copy for Hacker News, Reddit, V2EX, Juejin, and short social posts
- prepare v0.2.4 release notes and synchronize package version metadata

Zhihu and JoinQuant are intentionally excluded from the new launch sequence because they have already carried project posts.

## Verification

- 92 tests passed
- Ruff passed
- local Markdown links checked
- git diff --check clean
- mlquant.__version__ is 0.2.4