### PR TITLE
Link live Hugging Face artifacts and paper metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,11 @@ Languages: [English](README.md) | [简体中文](README.zh-CN.md) | [繁體中�
 | **Evidence, including failures** | Costs, turnover, baselines, caveats, and negative results stay visible |
 | **A contribution path** | CI, tests, report templates, Colab, and newcomer-sized research tasks |
 
-Hugging Face publishing is prepared through the
-[synthetic dataset/model export](docs/huggingface_artifacts.md); the export path
-explicitly excludes real and proprietary market data.
+Try the live Hugging Face artifacts: the
+[100,000-row synthetic dataset](https://huggingface.co/datasets/dddyym/ml-quant-trading-synthetic)
+and [213-input MLP checkpoint](https://huggingface.co/dddyym/ml-quant-trading-synthetic-mlp).
+Both come from the deterministic quick start and explicitly exclude real and
+proprietary market data; see the [artifact guide](docs/huggingface_artifacts.md).
 
 ## Quick Start
 

--- a/docs/huggingface_artifacts.md
+++ b/docs/huggingface_artifacts.md
@@ -8,11 +8,13 @@ from the deterministic synthetic quick start.
 
 | Hugging Face repository | Contents | Intended use |
 |---|---|---|
-| `dddyym/ml-quant-trading-synthetic` | Viewer-ready compressed CSV, generator config, checksum manifest, dataset card | Installation, CI, teaching, and pipeline smoke tests |
-| `dddyym/ml-quant-trading-synthetic-mlp` | PyTorch checkpoint, factor order, architecture config, metrics, model card | Checkpoint loading and inference smoke tests |
+| [`dddyym/ml-quant-trading-synthetic`](https://huggingface.co/datasets/dddyym/ml-quant-trading-synthetic) | Live viewer-ready 100,000-row compressed CSV, generator config, checksum manifest, dataset card | Installation, CI, teaching, and pipeline smoke tests |
+| [`dddyym/ml-quant-trading-synthetic-mlp`](https://huggingface.co/dddyym/ml-quant-trading-synthetic-mlp) | Live PyTorch checkpoint, 213-factor order, architecture config, metrics, model card | Checkpoint loading and inference smoke tests |
 
-Neither artifact represents real instruments, proprietary data, deployable
-alpha, or evidence of live performance.
+Both public repositories were verified with anonymous downloads; the dataset
+viewer renders its schema and rows, and the checkpoint passes the documented
+loading and inference smoke test. Neither artifact represents real instruments,
+proprietary data, deployable alpha, or evidence of live performance.
 
 ## Build locally
 
@@ -50,7 +52,7 @@ artifacts/huggingface/
 The dataset gzip stream uses a fixed timestamp so the same panel produces the
 same SHA-256 digest. Manifests record the source commit and file checksums.
 
-## Upload after authentication
+## Maintainer upload after authentication
 
 Install and authenticate the Hugging Face CLI locally. Never paste a full token
 into an issue, PR, notebook, or chat transcript.
@@ -77,7 +79,7 @@ hf upload dddyym/ml-quant-trading-synthetic-mlp \
   artifacts/huggingface/ml-quant-trading-synthetic-mlp .
 ```
 
-After upload:
+After a new upload:
 
 1. Confirm the dataset viewer renders rows and column types.
 2. Run the model-card loading snippet in a clean environment.

--- a/docs/visibility_status.md
+++ b/docs/visibility_status.md
@@ -7,6 +7,8 @@ This page tracks the current public launch surface for `ml-quant-trading`.
 - Repository: <https://github.com/initial-d/ml-quant-trading>
 - Paper: <https://arxiv.org/abs/2507.07107>
 - Hugging Face paper page (verified authorship claim): <https://huggingface.co/papers/2507.07107>
+- Hugging Face synthetic dataset: <https://huggingface.co/datasets/dddyym/ml-quant-trading-synthetic>
+- Hugging Face synthetic MLP checkpoint: <https://huggingface.co/dddyym/ml-quant-trading-synthetic-mlp>
 - alphaXiv page: <https://www.alphaxiv.org/abs/2507.07107>
 - Awesome Quant listing (Factor Analysis): <https://github.com/wilsonfreitas/awesome-quant#factor-analysis>
 - ernie55ernie Awesome Quant listing (Research Frameworks): <https://github.com/ernie55ernie/awesome-quant>
@@ -182,7 +184,7 @@ Primary ask:
 - Add more public-data mini reproductions with larger or differently constructed universes.
 - Ask new users to try the Dev Container and report first-run friction.
 - Post the v0.2.1 validation entrypoint release to one relevant community at a time with a customized note.
-- Define a safe Hugging Face demo artifact or model card that uses synthetic or redistributable data only.
+- Invite reproducibility feedback through the live synthetic Hugging Face dataset and model cards.
 - Follow up on open high-relevance awesome-list pull requests after maintainers have had time to review.
 - Follow up on the auto-refreshed Awesome Quant listing PR after maintainer review.
 - Set a GitHub social preview image through repository settings when browser upload access is available.

--- a/scripts/export_huggingface_artifacts.py
+++ b/scripts/export_huggingface_artifacts.py
@@ -131,6 +131,7 @@ tags:
 - quantitative-trading
 - reproducibility
 - pytorch
+- arxiv:2507.07107
 configs:
 - config_name: default
   data_files:
@@ -205,6 +206,7 @@ tags:
 - quantitative-trading
 - reproducibility
 - pytorch
+- arxiv:2507.07107
 ---
 
 # ml-quant-trading synthetic MLP smoke-test checkpoint

--- a/tests/test_export_huggingface_artifacts.py
+++ b/tests/test_export_huggingface_artifacts.py
@@ -61,8 +61,12 @@ def test_export_bundle_is_viewer_ready_and_explicitly_synthetic(tmp_path: Path):
     assert len(rows) == 4
     assert rows[-1]["tradable"] == "0"
     assert manifest["dataset_rows"] == 4
-    assert "no real instruments" in (dataset_dir / "README.md").read_text(encoding="utf-8")
-    assert "not as a market model" in (model_dir / "README.md").read_text(encoding="utf-8")
+    dataset_card = (dataset_dir / "README.md").read_text(encoding="utf-8")
+    model_card = (model_dir / "README.md").read_text(encoding="utf-8")
+    assert "no real instruments" in dataset_card
+    assert "not as a market model" in model_card
+    assert "arxiv:2507.07107" in dataset_card
+    assert "arxiv:2507.07107" in model_card
     assert json.loads((model_dir / "config.json").read_text())["in_dim"] == 2
     assert json.loads((model_dir / "feature_names.json").read_text()) == ["f1", "f2"]
 


### PR DESCRIPTION
Publishes the verified Hugging Face dataset and model entry points in the README and visibility docs. Adds arXiv metadata to both generated cards so future exports remain linked to paper 2507.07107.

Validation:
- targeted exporter tests: 2 passed
- prior full suite on the merged exporter: 94 passed
- GitHub CI will run the full Python 3.9/3.10/3.11 matrix